### PR TITLE
document minimum required gcloud sdk version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To use Flank, please sign up for Firebase Test Lab and install the Google Cloud 
 
 * Signup for [Firebase Test Lab](https://firebase.google.com/)
 
-* Install the [Google Cloud SDK](https://cloud.google.com/sdk/docs/)
+* Install the [Google Cloud SDK](https://cloud.google.com/sdk/docs/) (>= 149.0.0)
 
 ### Download
 


### PR DESCRIPTION
Some organizations will already have the GCloud SDK installed and will want to know what the minimum required version is. In our case, this is really helpful to know what version to upgrade to so we can read the changelog in between and perform any updates for our own FTL test runner (which we'd eventually like to migrate from).

149.0.0 seems to be right as that version introduces the "firebase" namespace which flank now uses (`gcloud firebase test android run...`), and after upgrading to this version tests run and pass.