### PR TITLE
Add --fail to curl recipe, use full parameter names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ Either [download Flank from here](https://bintray.com/flank1/Flank/download_file
 
 or 
 
-Use curl: ```curl -L https://dl.bintray.com/flank1/Flank/Flank-1.3.0.jar -o Flank-1.3.0.jar```
+Use curl: 
+
+```console
+curl --location --fail https://dl.bintray.com/flank1/Flank/Flank-1.3.0.jar --output Flank-1.3.0.jar
+```
 
 ### Run Tests
 


### PR DESCRIPTION
This PR add `--fail` which will make curl fail if response code is not 2xx, otherwise curl will happily write something like `404` page to the `--output` file and then `java -jar` will fail with unreadable error :)

Also, changed `-o` and `-L` to their full parameter names so people could better understand what's going on.