### PR TITLE
Make gcloud bucket configurable, enables Flank for free Firebase plan.

### DIFF
--- a/Flank/src/main/java/com/walmart/otto/Flank.java
+++ b/Flank/src/main/java/com/walmart/otto/Flank.java
@@ -37,7 +37,9 @@ public class Flank {
 
     toolManager = new ToolManager().load(loadTools(args[0], args[1], configurator));
 
-    configurator.setProjectName(getProjectName(toolManager));
+    if (configurator.getProjectName() == null) {
+      configurator.setProjectName(getProjectName(toolManager));
+    }
 
     List<String> testCases = getTestCaseNames(args);
 

--- a/Flank/src/main/java/com/walmart/otto/configurator/ConfigReader.java
+++ b/Flank/src/main/java/com/walmart/otto/configurator/ConfigReader.java
@@ -83,6 +83,10 @@ public class ConfigReader {
         configurator.setGsutil(value);
         break;
 
+      case "gcloud-bucket":
+        configurator.setProjectName(value);
+        break;
+
       case "environment-variables":
         configurator.setEnvironmentVariables(value);
         break;

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ If Flank hangs and nothing seems to be happening (even when debug mode is enable
 
 If you see `AccessDeniedException: 403` verify that:
 - The GCloud SDK is on the latest version
-- The Firebase project is on a paid subscription
+- The Firebase project is on a paid subscription (or you need to specify `gcloud-bucket` of the free account)
 - The Firebase account and project ID are in sync
 
 Follow below steps to set it:
@@ -109,6 +109,5 @@ gcloud auth login - To set gcloud to the correct google account.
 gcloud config set project <idOfYourProject> - To set gcloud to the correct project ID.
 
 ```
-Make sure that `<idOfYourProject>` belongs to a project that is subscribed to either Flame or Blaze (Paid subscriptions).
 
 If you are using the terminal in OS X and Flank gets stuck at around 250 shards its because of a setting in OS X. To fix it [please follow these instructions](https://blog.dekstroza.io/ulimit-shenanigans-on-osx-el-capitan/).

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ fetch-xml-files: If the result xml files should be fetched
 fetch-bucket: If the bucket containing logs and artifacts should be fetched
 gcloud-path: The path to the glcoud binary
 gsutil-path: The path to the gsutil binary
-
+gcloud-bucket: The Google Cloud Storage bucket to put/pull files during test run
 ```
 
 Example of a properties file:


### PR DESCRIPTION
Fixes #53. 

This PR allows user to set gcloud-bucket from free Firebase account and avoid paid plan if it's not required.