### PR TITLE
add support for --use-orchestrator

### DIFF
--- a/Flank/src/main/java/com/walmart/otto/configurator/ConfigReader.java
+++ b/Flank/src/main/java/com/walmart/otto/configurator/ConfigReader.java
@@ -103,6 +103,10 @@ public class ConfigReader {
         configurator.setFetchBucket(Boolean.parseBoolean(value));
         break;
 
+      case "use-orchestrator":
+        configurator.setUseOrchestrator(Boolean.parseBoolean(value));
+        break;
+
       default:
         break;
     }

--- a/Flank/src/main/java/com/walmart/otto/configurator/Configurator.java
+++ b/Flank/src/main/java/com/walmart/otto/configurator/Configurator.java
@@ -13,6 +13,7 @@ public class Configurator {
   private String projectName;
   private String directoriesToPull = "";
 
+  private boolean useOrchestrator = false;
   private boolean fetchXMLFiles = true;
   private boolean debug = false;
   private boolean fetchBucket = false;
@@ -157,5 +158,13 @@ public class Configurator {
 
   public void setFetchBucket(boolean fetchArtefacts) {
     this.fetchBucket = fetchArtefacts;
+  }
+
+  public boolean isUseOrchestrator() {
+    return useOrchestrator;
+  }
+
+  public void setUseOrchestrator(boolean useOrchestrator) {
+    this.useOrchestrator = useOrchestrator;
   }
 }

--- a/Flank/src/main/java/com/walmart/otto/tools/GcloudTool.java
+++ b/Flank/src/main/java/com/walmart/otto/tools/GcloudTool.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 public class GcloudTool extends Tool {
   private boolean printTests = true;

--- a/Flank/src/main/java/com/walmart/otto/tools/GcloudTool.java
+++ b/Flank/src/main/java/com/walmart/otto/tools/GcloudTool.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public class GcloudTool extends Tool {
   private boolean printTests = true;
@@ -32,6 +33,7 @@ public class GcloudTool extends Tool {
           "run",
           "--type",
           "instrumentation",
+          orchestratorFlag(),
           "--app",
           bucket + getSimpleName(getAppAPK()),
           "--test",
@@ -65,6 +67,13 @@ public class GcloudTool extends Tool {
     String[] cmdArray = gcloudList.toArray(new String[0]);
 
     executeGcloud(cmdArray, testCase);
+  }
+
+  private String orchestratorFlag() {
+    if (getConfigurator().isUseOrchestrator()) {
+      return "--use-orchestrator";
+    }
+    return "--no-use-orchestrator";
   }
 
   private void addParameterIfValueSet(List<String> list, String parameter, String value) {


### PR DESCRIPTION
Fixes #63 

Adds support for the test orchestrator. Can be enabled by the `use-orchestrator` flag in the `config.properties` file.