### PR TITLE
add support to use gcloud beta

### DIFF
--- a/Flank/src/main/java/com/walmart/otto/configurator/ConfigReader.java
+++ b/Flank/src/main/java/com/walmart/otto/configurator/ConfigReader.java
@@ -107,6 +107,10 @@ public class ConfigReader {
         configurator.setUseOrchestrator(Boolean.parseBoolean(value));
         break;
 
+      case "use-gcloud-beta":
+        configurator.setUseGCloudBeta(Boolean.parseBoolean(value));
+        break;
+
       default:
         break;
     }

--- a/Flank/src/main/java/com/walmart/otto/configurator/Configurator.java
+++ b/Flank/src/main/java/com/walmart/otto/configurator/Configurator.java
@@ -14,6 +14,7 @@ public class Configurator {
   private String directoriesToPull = "";
 
   private boolean useOrchestrator = false;
+  private boolean useGCloudBeta = false;
   private boolean fetchXMLFiles = true;
   private boolean debug = false;
   private boolean fetchBucket = false;
@@ -166,5 +167,13 @@ public class Configurator {
 
   public void setUseOrchestrator(boolean useOrchestrator) {
     this.useOrchestrator = useOrchestrator;
+  }
+
+  public boolean isUseGCloudBeta() {
+    return useGCloudBeta;
+  }
+
+  public void setUseGCloudBeta(boolean useGCloudBeta) {
+    this.useGCloudBeta = useGCloudBeta;
   }
 }

--- a/Flank/src/main/java/com/walmart/otto/tools/GcloudTool.java
+++ b/Flank/src/main/java/com/walmart/otto/tools/GcloudTool.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public class GcloudTool extends Tool {
   private boolean printTests = true;
@@ -26,6 +27,7 @@ public class GcloudTool extends Tool {
     String[] runGcloud =
         new String[] {
           getConfigurator().getGcloud(),
+          betaConfiguration(),
           "firebase",
           "test",
           "android",
@@ -63,6 +65,12 @@ public class GcloudTool extends Tool {
     addParameterIfValueSet(
         gcloudList, "--directories-to-pull", getConfigurator().getDirectoriesToPull());
 
+    gcloudList =
+        gcloudList
+            .stream()
+            .filter(param -> param != null && !param.isEmpty())
+            .collect(Collectors.toList());
+
     String[] cmdArray = gcloudList.toArray(new String[0]);
 
     executeGcloud(cmdArray, testCase);
@@ -73,6 +81,13 @@ public class GcloudTool extends Tool {
       return "--use-orchestrator";
     }
     return "--no-use-orchestrator";
+  }
+
+  private String betaConfiguration() {
+    if (getConfigurator().isUseGCloudBeta()) {
+      return "beta";
+    }
+    return "";
   }
 
   private void addParameterIfValueSet(List<String> list, String parameter, String value) {


### PR DESCRIPTION
Might be useful for some, especially to try newer features/behaviors in the `gcloud beta`.

Can be enabled via the `use-gcloud-beta` flag in the `config.properties` file.