### PR TITLE
Include shard index to results-dir name

### DIFF
--- a/Flank/src/main/java/com/walmart/otto/tools/GcloudTool.java
+++ b/Flank/src/main/java/com/walmart/otto/tools/GcloudTool.java
@@ -21,7 +21,7 @@ public class GcloudTool extends Tool {
     super(ToolManager.GCLOUD_TOOL, config);
   }
 
-  public void runGcloud(String testCase, String bucket)
+  public void runGcloud(String testCase, String bucket, int shardIndex)
       throws RuntimeException, IOException, InterruptedException {
     // don't quote arguments or ProcessBuilder will error in strange ways.
     String[] runGcloud =
@@ -52,7 +52,7 @@ public class GcloudTool extends Tool {
           "--timeout",
           getConfigurator().getShardTimeout() + "m",
           "--results-dir",
-          bucket.split("/")[3],
+          bucket.split("/")[3] + "/" + shardIndex,
           "--test-targets",
           testCase
         };

--- a/Flank/src/main/java/com/walmart/otto/tools/GsutilTool.java
+++ b/Flank/src/main/java/com/walmart/otto/tools/GsutilTool.java
@@ -239,7 +239,12 @@ public class GsutilTool extends Tool {
   private String[] deleteApp() {
     String[] deleteApp =
         new String[] {
-          getConfigurator().getGsutil(), "--quiet", "rm", "-r", bucket + getSimpleName(getAppAPK())
+          getConfigurator().getGsutil(),
+          "--quiet",
+          "-m",
+          "rm",
+          "-r",
+          bucket + "**/" + getSimpleName(getAppAPK())
         };
     return deleteApp;
   }
@@ -247,7 +252,12 @@ public class GsutilTool extends Tool {
   private String[] deleteTest() {
     String[] deleteTest =
         new String[] {
-          getConfigurator().getGsutil(), "--quiet", "rm", "-r", bucket + getSimpleName(getTestAPK())
+          getConfigurator().getGsutil(),
+          "--quiet",
+          "-m",
+          "rm",
+          "-r",
+          bucket + "**/" + getSimpleName(getTestAPK())
         };
     return deleteTest;
   }

--- a/Flank/src/main/java/com/walmart/otto/tools/ProcessBuilder.java
+++ b/Flank/src/main/java/com/walmart/otto/tools/ProcessBuilder.java
@@ -35,6 +35,7 @@ public class ProcessBuilder {
     return status;
   }
 
+  @SuppressWarnings("deprecation")
   public void kill() {
     if (seInfo != null) {
       seInfo.stop();


### PR DESCRIPTION
Using the same result-dir value causes some results artifacts (video, logcat, etc) to be overwritten because they all have the same name. In this PR we are changing the results-dir format to include the shard so that they will be in separate folders.

We additionally have to change the way we delete the upload app/instrumentation apks because looks like Firebase copies them to the all the result directories.