### PR TITLE
Added support for devices specification on config.properties

### DIFF
--- a/Flank/build.gradle
+++ b/Flank/build.gradle
@@ -8,7 +8,7 @@ repositories {
 }
 
 group 'com.walmart.otto'
-version '1.5.0'
+version '1.6.0'
 
 apply plugin: 'java'
 apply plugin: 'findbugs'

--- a/Flank/src/main/java/com/walmart/otto/Flank.java
+++ b/Flank/src/main/java/com/walmart/otto/Flank.java
@@ -4,6 +4,7 @@ import com.linkedin.dex.parser.DexParser;
 import com.linkedin.dex.parser.TestMethod;
 import com.walmart.otto.configurator.ConfigReader;
 import com.walmart.otto.configurator.Configurator;
+import com.walmart.otto.models.Device;
 import com.walmart.otto.reporter.PriceReporter;
 import com.walmart.otto.reporter.TimeReporter;
 import com.walmart.otto.shards.ShardExecutor;
@@ -189,7 +190,11 @@ public class Flank {
               + " ("
               + numberOfShards
               + " shards in total) will be executed on: "
-              + configurator.getDeviceIds());
+              + configurator
+                  .getDevices()
+                  .stream()
+                  .map(Device::getId)
+                  .reduce((s, s2) -> s + ", " + s2));
       return;
     }
   }

--- a/Flank/src/main/java/com/walmart/otto/configurator/ConfigReader.java
+++ b/Flank/src/main/java/com/walmart/otto/configurator/ConfigReader.java
@@ -1,5 +1,6 @@
 package com.walmart.otto.configurator;
 
+import com.walmart.otto.models.Device;
 import java.io.*;
 import java.util.Arrays;
 import java.util.Properties;
@@ -32,6 +33,7 @@ public class ConfigReader {
     return configurator;
   }
 
+  @SuppressWarnings("deprecation")
   private void setProperty(String property, String value) throws IllegalArgumentException {
     if (value.isEmpty()) {
       return;
@@ -40,8 +42,24 @@ public class ConfigReader {
     value = value.replaceAll(" ", "");
 
     switch (property) {
+      case "devices":
+        configurator.addDevices(Device.parseDevices(value));
+        break;
+
       case "deviceIds":
         configurator.setDeviceIds(value);
+        break;
+
+      case "locales":
+        configurator.setLocales(value);
+        break;
+
+      case "orientations":
+        configurator.setOrientations(value);
+        break;
+
+      case "os-version-ids":
+        configurator.setOsVersionIds(value);
         break;
 
       case "numShards":
@@ -58,18 +76,6 @@ public class ConfigReader {
 
       case "shard-duration":
         configurator.setShardDuration(Integer.parseInt(value));
-        break;
-
-      case "locales":
-        configurator.setLocales(value);
-        break;
-
-      case "orientations":
-        configurator.setOrientations(value);
-        break;
-
-      case "os-version-ids":
-        configurator.setOsVersionIds(value);
         break;
 
       case "debug-prints":

--- a/Flank/src/main/java/com/walmart/otto/configurator/Configurator.java
+++ b/Flank/src/main/java/com/walmart/otto/configurator/Configurator.java
@@ -1,14 +1,18 @@
 package com.walmart.otto.configurator;
 
+import com.walmart.otto.models.Device;
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 public class Configurator {
-  private String deviceIds = "Nexus6P";
-  private String locales = "en";
-  private String orientations = "portrait";
-  private String osVersionIds = "25";
+  private List<String> deviceIds = new ArrayList<>(Collections.singletonList("Nexus6P"));
+  private List<String> locales = new ArrayList<>(Collections.singletonList("en"));
+  private List<String> orientations = new ArrayList<>(Collections.singletonList("portrait"));
+  private List<String> osVersionIds = new ArrayList<>(Collections.singletonList("25"));
+  private List<Device> devices = new ArrayList<>();
   private String gcloud = "gcloud";
   private String gsutil = "gsutil";
   private String environmentVariables = "";
@@ -24,6 +28,10 @@ public class Configurator {
   private int shardIndex = -1;
   private int shardTimeout = 5;
   private int shardDuration = 120;
+
+  public Configurator() {
+    setupDevices();
+  }
 
   private List<String> skipTests = Collections.emptyList();
 
@@ -43,36 +51,36 @@ public class Configurator {
     this.shardIndex = shardIndex;
   }
 
-  public String getDeviceIds() {
-    return deviceIds;
-  }
-
+  @Deprecated
   public void setDeviceIds(String deviceIds) {
-    this.deviceIds = deviceIds;
+    this.deviceIds = Arrays.asList(deviceIds.split(","));
+    setupDevices();
   }
 
-  public String getOsVersionIds() {
-    return osVersionIds;
-  }
-
+  @Deprecated
   public void setOsVersionIds(String osVersionIds) {
-    this.osVersionIds = osVersionIds;
+    this.osVersionIds = Arrays.asList(osVersionIds.split(","));
+    setupDevices();
   }
 
-  public String getLocales() {
-    return locales;
-  }
-
+  @Deprecated
   public void setLocales(String locales) {
-    this.locales = locales;
+    this.locales = Arrays.asList(locales.split(","));
+    setupDevices();
   }
 
-  public String getOrientations() {
-    return orientations;
-  }
-
+  @Deprecated
   public void setOrientations(String orientations) {
-    this.orientations = orientations;
+    this.orientations = Arrays.asList(orientations.split(","));
+    setupDevices();
+  }
+
+  public void addDevices(List<Device> devices) {
+    this.devices = devices;
+  }
+
+  public List<Device> getDevices() {
+    return devices;
   }
 
   public boolean isDebug() {
@@ -187,5 +195,24 @@ public class Configurator {
 
   public void setSkipTests(List<String> skipTests) {
     this.skipTests = skipTests;
+  }
+
+  private void setupDevices() {
+    devices = new ArrayList<>();
+    for (String locale : locales) {
+      for (String deviceId : deviceIds) {
+        for (String osVersion : osVersionIds) {
+          for (String orientation : orientations) {
+            devices.add(
+                new Device.Builder()
+                    .setId(deviceId)
+                    .setLocale(locale)
+                    .setOrientation(orientation)
+                    .setOsVersion(osVersion)
+                    .build());
+          }
+        }
+      }
+    }
   }
 }

--- a/Flank/src/main/java/com/walmart/otto/models/Device.java
+++ b/Flank/src/main/java/com/walmart/otto/models/Device.java
@@ -1,0 +1,117 @@
+package com.walmart.otto.models;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Device {
+
+  private final String id;
+  private final String locale;
+  private final String orientation;
+  private final String osVersion;
+
+  public String getId() {
+    return id;
+  }
+
+  public String getLocale() {
+    return locale;
+  }
+
+  public String getOrientation() {
+    return orientation;
+  }
+
+  public String getOsVersion() {
+    return osVersion;
+  }
+
+  @Override
+  public String toString() {
+    return "model="
+        + id
+        + ",locale="
+        + locale
+        + ",orientation="
+        + orientation
+        + ",version="
+        + osVersion;
+  }
+
+  private Device(String id, String locale, String orientation, String osVersion) {
+    this.id = id;
+    this.locale = locale;
+    this.orientation = orientation;
+    this.osVersion = osVersion;
+  }
+
+  public static class Builder {
+
+    private String id = "Nexus6P";
+    private String locale = "en";
+    private String orientation = "portrait";
+    private String osVersion = "25";
+
+    public Builder setId(String id) {
+      this.id = id;
+      return this;
+    }
+
+    public Builder setLocale(String locale) {
+      this.locale = locale;
+      return this;
+    }
+
+    public Builder setOrientation(String orientation) {
+      this.orientation = orientation;
+      return this;
+    }
+
+    public Builder setOsVersion(String osVersion) {
+      this.osVersion = osVersion;
+      return this;
+    }
+
+    public Device build() {
+      return new Device(this.id, this.locale, this.orientation, this.osVersion);
+    }
+  }
+
+  public static List<Device> parseDevices(String input) {
+    List<Device> devices = new ArrayList<>();
+    String[] deviceConfigs = input.split(",");
+
+    for (String deviceConfig : deviceConfigs) {
+
+      Builder builder = new Builder();
+      String[] properties = deviceConfig.split(";");
+
+      for (String property : properties) {
+        String[] keyValue = property.split(":");
+        String key = keyValue[0];
+        String value = keyValue[1];
+        switch (key) {
+          case "model":
+            builder.setId(value);
+            break;
+          case "version":
+            builder.setOsVersion(value);
+            break;
+          case "orientation":
+            builder.setOrientation(value);
+            break;
+          case "locale":
+            builder.setLocale(value);
+            break;
+
+          default:
+            break;
+        }
+      }
+
+      devices.add(builder.build());
+    }
+
+    return devices;
+  }
+}

--- a/Flank/src/main/java/com/walmart/otto/shards/ShardExecutor.java
+++ b/Flank/src/main/java/com/walmart/otto/shards/ShardExecutor.java
@@ -1,6 +1,7 @@
 package com.walmart.otto.shards;
 
 import com.walmart.otto.configurator.Configurator;
+import com.walmart.otto.models.Device;
 import com.walmart.otto.tools.GcloudTool;
 import com.walmart.otto.tools.GsutilTool;
 import com.walmart.otto.tools.ToolManager;
@@ -50,7 +51,14 @@ public class ShardExecutor {
       futures.add(executeShard(shards.get(shardIndex), bucket, shardIndex));
     } else {
       System.out.println(
-          shards.size() + " shards will be executed on: " + configurator.getDeviceIds() + "\n");
+          shards.size()
+              + " shards will be executed on: "
+              + configurator
+                  .getDevices()
+                  .stream()
+                  .map(Device::getId)
+                  .reduce((s, s2) -> s + ", " + s2)
+              + "\n");
 
       for (int i = 0; i < shards.size(); i++) {
         printTests(shards.get(i), i);

--- a/Flank/src/main/java/com/walmart/otto/tools/GcloudTool.java
+++ b/Flank/src/main/java/com/walmart/otto/tools/GcloudTool.java
@@ -2,6 +2,7 @@ package com.walmart.otto.tools;
 
 import static com.walmart.otto.utils.FileUtils.getSimpleName;
 
+import com.walmart.otto.models.Device;
 import com.walmart.otto.reporter.TimeReporter;
 import com.walmart.otto.utils.FileUtils;
 import com.walmart.otto.utils.FilterUtils;
@@ -41,14 +42,6 @@ public class GcloudTool extends Tool {
           bucket + getSimpleName(getTestAPK()),
           "--results-bucket",
           "gs://" + bucket.split("/")[2],
-          "--device-ids",
-          getConfigurator().getDeviceIds(),
-          "--os-version-ids",
-          getConfigurator().getOsVersionIds(),
-          "--locales",
-          getConfigurator().getLocales(),
-          "--orientations",
-          getConfigurator().getOrientations(),
           "--timeout",
           getConfigurator().getShardTimeout() + "m",
           "--results-dir",
@@ -58,6 +51,10 @@ public class GcloudTool extends Tool {
         };
 
     List<String> gcloudList = new ArrayList<>(Arrays.asList(runGcloud));
+    for (Device device : getConfigurator().getDevices()) {
+      gcloudList.add("--device");
+      gcloudList.add(device.toString());
+    }
 
     addParameterIfValueSet(
         gcloudList, "--environment-variables", getConfigurator().getEnvironmentVariables());

--- a/Flank/src/test/java/com/walmart/otto/models/DeviceTest.java
+++ b/Flank/src/test/java/com/walmart/otto/models/DeviceTest.java
@@ -1,0 +1,41 @@
+package com.walmart.otto.models;
+
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+
+public class DeviceTest {
+
+  @Test
+  public void testDefaultValues() {
+    Device device = new Device.Builder().build();
+    assertEquals("Nexus6P", device.getId());
+    assertEquals("en", device.getLocale());
+    assertEquals("portrait", device.getOrientation());
+    assertEquals("25", device.getOsVersion());
+  }
+
+  @Test
+  public void testToStringWillMatchFirebaseExpectedConfig() {
+    Device device = new Device.Builder().build();
+    assertEquals("model=Nexus6P,locale=en,orientation=portrait,version=25", device.toString());
+  }
+
+  @Test
+  public void testParsingDevice() {
+    String exampleInput =
+        "model:Nexus5X;version:23;orientation:landscape;locale:br,model:Nexus6P;version:24,model:pixel;version:26";
+    List<Device> devices = Device.parseDevices(exampleInput);
+    List<String> expectedResult =
+        Arrays.asList(
+            "model=Nexus5X,locale=br,orientation=landscape,version=23",
+            "model=Nexus6P,locale=en,orientation=portrait,version=24",
+            "model=pixel,locale=en,orientation=portrait,version=26");
+
+    for (int i = 0; i < 3; i++) {
+      assertEquals(expectedResult.get(i), devices.get(i).toString());
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ To use Flank, please sign up for Firebase Test Lab and install the Google Cloud 
 
 ### Download
 
-Either [download Flank from here](https://bintray.com/flank1/Flank/download_file?file_path=Flank-1.5.0.jar)
+Either [download Flank from here](https://bintray.com/flank1/Flank/download_file?file_path=Flank-1.6.0.jar)
 
-or 
+or
 
-Use curl: 
+Use curl:
 
 ```console
-curl --location --fail https://dl.bintray.com/flank1/Flank/Flank-1.5.0.jar --output Flank-1.5.0.jar
+curl --location --fail https://dl.bintray.com/flank1/Flank/Flank-1.6.0.jar --output Flank-1.6.0.jar
 ```
 
 ### Run Tests
@@ -29,7 +29,7 @@ curl --location --fail https://dl.bintray.com/flank1/Flank/Flank-1.5.0.jar --out
 To runs tests with Flank you will need the app and test apk's. You can specify in which package you would like tests to run. A single class or test can also be executed (package_name.class_name#method_name). If no package name is provided all the tests will be executed. Usage:
 
 ```
-java -jar Flank-1.5.0.jar <app-apk> <test-apk> [package-name]
+java -jar Flank-1.6.0.jar <app-apk> <test-apk> [package-name]
 ```
 
 When the executions are completed Flanks will fetch the xml result files, add device name to the tests and store the files in a folder named: ```results```.
@@ -41,14 +41,11 @@ It's possible to configure Flank by including a Java properties file in the root
 Following properties can be configured:
 
 ```
-deviceIds: The ID:s of the devices to run the tests on
-os-version-ids: The API-levels of the devices to run the tests on
-orientations: The orientations, portrait, landscape or both
-locales: The device locales
-environment-variables: To set environment variables. Can also be used to enable code coverage 
+device: Device Id, OSVersion, orientation, locale; Default values are `Nexus6P`, `25`, `portrait` and `en`
+environment-variables: To set environment variables. Can also be used to enable code coverage
 directories-to-pull: If directories from the device should be pulled
 use-orchestrator: To enable Android Test Orchestrator
-shard-timeout: Timeout in minutes for each shard 
+shard-timeout: Timeout in minutes for each shard
 shard-duration: Duration in seconds for each shard
 
 numShards: Number of shards
@@ -58,30 +55,33 @@ fetch-xml-files: If the result xml files should be fetched
 fetch-bucket: If the bucket containing logs and artifacts should be fetched
 gcloud-path: The path to the glcoud binary
 gsutil-path: The path to the gsutil binary
-gcloud-bucket: The Google Cloud Storage bucket to use. If not specified Flank will create one. 
+gcloud-bucket: The Google Cloud Storage bucket to use. If not specified Flank will create one.
 use-gcloud-beta: If gcloud beta should be used
+
+deviceIds: The ID:s of the devices to run the tests on (deprecated, should not be used in conjunction with `device`)
+os-version-ids: The API-levels of the devices to run the tests on (deprecated, should not be used in conjunction with `device`)
+orientations: The orientations, portrait, landscape or both (deprecated, should not be used in conjunction with `device`)
+locales: The device locales (deprecated, should not be used in conjunction with `device`)
 ```
 
 Example of a properties file:
 
 ```
-deviceIds=Nexus5X,Nexus6P  
-os-version-ids=23,24   
-orientations=portrait  
-locales=en,sv  
 environment-variables=coverage=true,coverageFile=/sdcard/tempDir/coverage.ec
 directories-to-pull=/sdcard
-shard-timeout=5 
+shard-timeout=5
 shard-duration=120  
+devices=model:Nexus5X;version:23;orientation:portrait;locale:en,\
+        model:Nexus6P;version:24,\
+        model:pixel;version:26
 
 numShards=  
-shardIndex= 
+shardIndex=
 debug-prints=false  
 fetch-xml-files=true
 fetch-bucket=true
 gcloud-path=
 gsutil-path=
-
 ```
 
 ### Configurable Shards


### PR DESCRIPTION
As [the official documentation](https://cloud.google.com/sdk/gcloud/reference/firebase/test/android/run), Firebase Test Lab has depretaced the use of `--device-ids`, `--locales`, `--orientations` and `--os-version-ids` in order to accept multiple `--device` entries.

This PR adds the possibility to use the `--device` entries by configuring, on `config.properties` the list of devices configurations.  For example:
```
environment-variables=coverage=true,coverageFile=/sdcard/tempDir/coverage.ec
directories-to-pull=/sdcard
shard-timeout=5
shard-duration=120  
devices=model:Nexus5X;version:23;orientation:portrait;locale:en,\
        model:Nexus6P;version:24,\
        model:pixel;version:26

numShards=  
shardIndex=
debug-prints=false  
fetch-xml-files=true
fetch-bucket=true
gcloud-path=
gsutil-path=
```
Will create the devices:
```
--device model=Nexus5X,locale=br,orientation=landscape,version=23
--device model=Nexus6P,locale=en,orientation=portrait,version=24
--device model=pixel,locale=en,orientation=portrait,version=26"
```

PS: Note that the project's default values are still respected
PS2: The project still support the old type of configuration (which has been also deprecated in the project in order for new adopters to use the new and correct way), so there's no breaking changes for old users.

This should fix #32