### PR TITLE
Test reports aggregation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ shifu-java-client/.gradle
 ## File-based project format:
 *.ipr
 *.iws
+
+.DS_Store

--- a/Flank/build.gradle
+++ b/Flank/build.gradle
@@ -8,7 +8,7 @@ repositories {
 }
 
 group 'com.walmart.otto'
-version '1.7.0-SOUNDCLOUD'
+version '1.6.0'
 
 apply plugin: 'java'
 apply plugin: 'findbugs'

--- a/Flank/build.gradle
+++ b/Flank/build.gradle
@@ -8,7 +8,7 @@ repositories {
 }
 
 group 'com.walmart.otto'
-version '1.6.0'
+version '1.7.0-SOUNDCLOUD'
 
 apply plugin: 'java'
 apply plugin: 'findbugs'
@@ -22,6 +22,8 @@ tasks.withType(FindBugs) {
 
 dependencies {
     compile 'com.linkedin.dextestparser:parser:1.1.0'
+    compile 'com.samskivert:jmustache:1.13'
+    compileOnly 'com.google.code.findbugs:annotations:3.0.1'
     testCompile group: 'junit', name: 'junit', version: '4.11'
 }
 

--- a/Flank/src/main/java/com/walmart/otto/aggregator/ArtifactsProcessor.java
+++ b/Flank/src/main/java/com/walmart/otto/aggregator/ArtifactsProcessor.java
@@ -1,0 +1,233 @@
+package com.walmart.otto.aggregator;
+
+import com.walmart.otto.configurator.Configurator;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.Year;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+class ArtifactsProcessor {
+
+  private static final DateTimeFormatter DATE_TIME_FORMATTER =
+      new DateTimeFormatterBuilder()
+          .appendPattern("MM-dd HH:mm:ss.SSS")
+          .parseDefaulting(ChronoField.YEAR_OF_ERA, Year.now().getValue())
+          .toFormatter(Locale.ENGLISH)
+          .withZone(ZoneId.systemDefault());
+
+  private static final Pattern TEST_STARTED_LINE =
+      Pattern.compile(".+: I/TestRunner\\(\\d+\\): started: .+");
+
+  private static final Duration TEN_SECONDS = Duration.ofSeconds(10);
+
+  private static final String CUT_VIDEO_COMMAND_TEMPLATE = "ffmpeg -i %s -ss %s -to %s %s";
+
+  private Configurator configurator;
+
+  public ArtifactsProcessor(Configurator configurator) {
+    this.configurator = configurator;
+  }
+
+  public void generateArtifactsForTestCase(Path reportBaseDir, String matrixName, TestCase testCase)
+      throws IOException, InterruptedException {
+
+    final Pattern targetTestStartedLine = createTestStartedPattern(testCase);
+    final Pattern targetTestFinishedLine = createTestFinishedPattern(testCase);
+
+    Path sourceLogcatFile =
+        reportBaseDir.resolve(
+            testCase.getShardName() + File.separator + matrixName + File.separator + "logcat");
+
+    Path logcatsFolder = getOrCreateChildFolder(reportBaseDir, "logcat");
+    Path testLogcatFile = logcatsFolder.resolve(testCase.getId() + ".txt");
+
+    Path entireLogcatFile = logcatsFolder.resolve("shard_" + testCase.getShardName() + ".txt");
+    Files.copy(sourceLogcatFile, entireLogcatFile, StandardCopyOption.REPLACE_EXISTING);
+
+    Instant firstTestStartedTime = null;
+    Instant targetTestStartedTime = null;
+    Instant targetTestFinishedTime = null;
+
+    if (!Files.exists(sourceLogcatFile)) {
+      System.err.printf(
+          "Can't process logcat file for %s. Expected file %s does not exist.%n",
+          testCase.getId(), sourceLogcatFile.toString());
+      return;
+    }
+
+    try (BufferedReader reader = Files.newBufferedReader(sourceLogcatFile);
+        BufferedWriter writer = Files.newBufferedWriter(testLogcatFile, Charset.forName("UTF-8"))) {
+
+      String line;
+      boolean copy = false;
+
+      while ((line = reader.readLine()) != null) {
+
+        if (firstTestStartedTime == null && TEST_STARTED_LINE.matcher(line).matches()) {
+          firstTestStartedTime = extractInstant(line);
+        }
+
+        if (targetTestStartedLine.matcher(line).matches()) {
+          targetTestStartedTime = extractInstant(line);
+          copy = true;
+        }
+
+        if (copy) {
+          writer.write(line);
+          writer.newLine();
+        }
+
+        if (targetTestFinishedLine.matcher(line).matches()) {
+          targetTestFinishedTime = extractInstant(line);
+          break;
+        }
+      }
+    }
+
+    processVideo(
+        reportBaseDir,
+        matrixName,
+        testCase,
+        firstTestStartedTime,
+        targetTestStartedTime,
+        targetTestFinishedTime);
+  }
+
+  private void processVideo(
+      Path reportBaseDir,
+      String matrixName,
+      TestCase testCase,
+      Instant firstTestExecuted,
+      Instant startOfTargetTest,
+      Instant endOfTargetTest)
+      throws IOException, InterruptedException {
+
+    Path videoFile =
+        reportBaseDir.resolve(
+            testCase.getShardName() + File.separator + matrixName + File.separator + "video.mp4");
+
+    if (!Files.exists(videoFile)) {
+      System.err.printf(
+          "Can't process video file for %s. Expected file %s does not exist.%n",
+          testCase.getId(), videoFile.toString());
+      return;
+    }
+
+    Path videosFolder = getOrCreateChildFolder(reportBaseDir, "video");
+    Path outputFile = videosFolder.resolve(testCase.getId() + ".mp4");
+    Path entireVideoFile = videosFolder.resolve("shard_" + testCase.getShardName() + ".mp4");
+
+    Files.copy(videoFile, entireVideoFile, StandardCopyOption.REPLACE_EXISTING);
+
+    if (!configurator.isGenerateSplitVideo()) {
+      return; // if we don't split the video it's enough to copy the full one
+    }
+
+    if (checkTimePreconditions(firstTestExecuted, startOfTargetTest, endOfTargetTest)) {
+
+      Duration normalizedStartOfTest = Duration.between(firstTestExecuted, startOfTargetTest);
+      if (normalizedStartOfTest.getSeconds() > 10) {
+        normalizedStartOfTest = normalizedStartOfTest.minusSeconds(10);
+      }
+
+      Duration normalizedEndOfTest =
+          Duration.between(firstTestExecuted, endOfTargetTest).plus(TEN_SECONDS);
+
+      String normalizedStartOfTestString = TimeUtils.formatDuration(normalizedStartOfTest);
+      String normalizedEndOfTestString = TimeUtils.formatDuration(normalizedEndOfTest);
+
+      String command =
+          String.format(
+              CUT_VIDEO_COMMAND_TEMPLATE,
+              videoFile.toString(),
+              normalizedStartOfTestString,
+              normalizedEndOfTestString,
+              outputFile.toString());
+      if (this.configurator.isDebug()) {
+        System.out.println(command);
+      }
+      runCommandSafely(command);
+    } else {
+      if (this.configurator.isDebug()) {
+        System.out.printf(
+            "Unable to process video for: %s shard: %s firstTestExecuted %s startOfTargetTest %s endOftest %s%n",
+            testCase.getId(),
+            testCase.getShardName(),
+            firstTestExecuted,
+            startOfTargetTest,
+            endOfTargetTest);
+      }
+    }
+  }
+
+  private void runCommandSafely(String command) {
+    try {
+      Runtime.getRuntime().exec(command);
+    } catch (IOException e) {
+      System.err.println("Error running ffmpg: " + e.getMessage() + " Is it installed?");
+    }
+  }
+
+  private boolean checkTimePreconditions(
+      Instant startOfLogcat, Instant startOfTest, Instant endOfTest) {
+    return startOfLogcat != null
+        && startOfTest != null
+        && endOfTest != null
+        && startOfLogcat.isBefore(endOfTest)
+        && startOfTest.isBefore(endOfTest);
+  }
+
+  private Instant extractInstant(String line) {
+    Pattern timePattern = Pattern.compile("(.*): \\w/.*");
+    Matcher matcher = timePattern.matcher(line);
+    if (matcher.find()) {
+      String time = matcher.group(1);
+      return DATE_TIME_FORMATTER.parse(time, Instant::from);
+    } else {
+      throw new IllegalStateException("Cant extract time from: " + line);
+    }
+  }
+
+  private Path getOrCreateChildFolder(Path base, String child) throws IOException {
+    Path folder = base.resolve(child);
+    if (!Files.exists(folder)) {
+      try {
+        Files.createDirectory(folder);
+      } catch (FileAlreadyExistsException e) {
+        // it's ok to ignore
+      }
+    }
+    return folder;
+  }
+
+  private Pattern createTestFinishedPattern(TestCase testCase) {
+    String testFinishedRegex =
+        String.format(
+            ".+: I/TestRunner\\(\\d+\\): finished: %s\\(%s\\)",
+            testCase.getTestName(), testCase.getClassName());
+    return Pattern.compile(testFinishedRegex);
+  }
+
+  private Pattern createTestStartedPattern(TestCase testCase) {
+    String testStartedRegex =
+        String.format(
+            ".+: I/TestRunner\\(\\d+\\): started: %s\\(%s\\)",
+            testCase.getTestName(), testCase.getClassName());
+    return Pattern.compile(testStartedRegex);
+  }
+}

--- a/Flank/src/main/java/com/walmart/otto/aggregator/HtmlReport.java
+++ b/Flank/src/main/java/com/walmart/otto/aggregator/HtmlReport.java
@@ -1,0 +1,101 @@
+package com.walmart.otto.aggregator;
+
+import static java.util.Comparator.comparing;
+import static java.util.Comparator.comparingLong;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toList;
+
+import com.samskivert.mustache.Mustache;
+import com.samskivert.mustache.Template;
+import com.walmart.otto.configurator.Configurator;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+
+class HtmlReport {
+
+  private final Configurator configurator;
+
+  HtmlReport(Configurator configurator) {
+    this.configurator = configurator;
+  }
+
+  public void generate(String baseUrl, Path outputFile, List<TestSuite> testSuites)
+      throws HtmlReportGenerationException {
+
+    long testsCount = testSuites.stream().mapToInt(TestSuite::getTestsCount).sum();
+    long failuresCount = testSuites.stream().mapToInt(TestSuite::getFailuresCount).sum();
+
+    List<TestClass> testClasses =
+        testSuites
+            .stream()
+            .flatMap(testSuite -> testSuite.getTestCaseList().stream())
+            .collect(groupingBy(TestCase::getClassName))
+            .values()
+            .stream()
+            .map(this::createTestClass)
+            .sorted(comparingLong(TestClass::getFailingTestsCount).reversed())
+            .collect(toList());
+
+    int durationSeconds = testSuites.stream().mapToInt(s -> (int) s.getDurantion()).sum();
+    Duration duration = Duration.ofSeconds(durationSeconds);
+
+    long shardsCount =
+        testSuites
+            .stream()
+            .flatMap(testSuite -> testSuite.getTestCaseList().stream())
+            .map(TestCase::getShardName)
+            .distinct()
+            .count();
+
+    HashMap<Object, Object> parameters = new HashMap<>();
+    parameters.put("testsCount", testsCount);
+    parameters.put("failuresCount", failuresCount);
+    parameters.put("passedCounts", testsCount - failuresCount);
+    parameters.put("failed", failuresCount > 0);
+    parameters.put("testClasses", testClasses);
+    parameters.put("duration", TimeUtils.formatDuration(duration));
+    parameters.put("shardsCount", shardsCount);
+    parameters.put("baseUrl", baseUrl);
+    parameters.put("splitVideo", configurator.isGenerateSplitVideo());
+
+    InputStreamReader inputStreamReader;
+    try {
+      InputStream templateStream =
+          ReportsAggregator.class.getResourceAsStream("/tests_results.mustache");
+      inputStreamReader = new InputStreamReader(templateStream, "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      throw new HtmlReportGenerationException(e);
+    }
+
+    Template template = Mustache.compiler().compile(inputStreamReader);
+
+    try (BufferedWriter writer = Files.newBufferedWriter(outputFile, Charset.forName("UTF-8"))) {
+      template.execute(parameters, writer);
+      writer.flush();
+      System.out.println("HTML report written to: " + outputFile.toString());
+    } catch (IOException ex) {
+      System.out.println("Failed to generate HTML report");
+      throw new HtmlReportGenerationException(ex);
+    }
+  }
+
+  private TestClass createTestClass(List<TestCase> testCases) {
+    // we want the failing test cases to be the firsts in the list
+    List<TestCase> sorted =
+        testCases
+            .stream()
+            .sorted(comparing(TestCase::isFailure).reversed())
+            .collect(Collectors.toList());
+    return new TestClass(sorted);
+  }
+}

--- a/Flank/src/main/java/com/walmart/otto/aggregator/HtmlReportGenerationException.java
+++ b/Flank/src/main/java/com/walmart/otto/aggregator/HtmlReportGenerationException.java
@@ -1,0 +1,8 @@
+package com.walmart.otto.aggregator;
+
+public class HtmlReportGenerationException extends Exception {
+
+  public HtmlReportGenerationException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/Flank/src/main/java/com/walmart/otto/aggregator/JunitReport.java
+++ b/Flank/src/main/java/com/walmart/otto/aggregator/JunitReport.java
@@ -1,0 +1,202 @@
+package com.walmart.otto.aggregator;
+
+import com.walmart.otto.utils.XMLUtils;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.io.BufferedWriter;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+class JunitReport {
+
+  private static final String TESTCASE_TAG = "testcase";
+  private static final String TESTSUITE_TAG = "testsuite";
+  private static final String ERROR_TAG = "error";
+  private static final String FAILURE_TAG = "failure";
+  private static final String SKIPPED_TAG = "skipped";
+
+  private static final String NAME_ATTRIBUTE = "name";
+  private static final String CLASSNAME_ATTRIBUTE = "classname";
+  private static final String TESTS_ATTRIBUTE = "tests";
+  private static final String FAILURES_ATTRIBUTE = "failures";
+  private static final String ERRORS_ATTRIBUTE = "errors";
+  private static final String SKIPPED_ATTRIBUTE = "skipped";
+  private static final String TIME_ATTRIBUTE = "time";
+  private static final String HOSTNAME_ATTRIBUTE = "hostname";
+
+  public void generate(Path outputFile, List<TestSuite> testSuites)
+      throws XmlReportGenerationException {
+
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    factory.setExpandEntityReferences(false);
+
+    DocumentBuilder documentBuilder;
+    try {
+      documentBuilder = factory.newDocumentBuilder();
+    } catch (ParserConfigurationException e) {
+      throw new XmlReportGenerationException(e);
+    }
+
+    Document document = documentBuilder.newDocument();
+    document.setXmlStandalone(false);
+
+    long tests = testSuites.stream().mapToInt(TestSuite::getTestsCount).sum();
+    long failures = testSuites.stream().mapToInt(TestSuite::getFailuresCount).sum();
+    long errors = testSuites.stream().mapToInt(TestSuite::getErrorsCount).sum();
+    long skipped = testSuites.stream().mapToInt(TestSuite::getSkippedCount).sum();
+    double duration = testSuites.stream().mapToDouble(TestSuite::getDurantion).sum();
+
+    Element testSuiteElement = document.createElement(TESTSUITE_TAG);
+    testSuiteElement.setAttribute(TESTS_ATTRIBUTE, Long.toString(tests));
+    testSuiteElement.setAttribute(FAILURES_ATTRIBUTE, Long.toString(failures));
+    testSuiteElement.setAttribute(ERRORS_ATTRIBUTE, Long.toString(errors));
+    testSuiteElement.setAttribute(SKIPPED_ATTRIBUTE, Long.toString(skipped));
+    testSuiteElement.setAttribute(TIME_ATTRIBUTE, new DecimalFormat("#0.00").format(duration));
+    testSuiteElement.setAttribute(HOSTNAME_ATTRIBUTE, "localhost");
+
+    document.appendChild(testSuiteElement);
+
+    for (TestSuite testSuite : testSuites) {
+      for (TestCase testCase : testSuite.getTestCaseList()) {
+        Element testCaseElement = document.createElement(TESTCASE_TAG);
+        testCaseElement.setAttribute(NAME_ATTRIBUTE, testCase.getTestName());
+        testCaseElement.setAttribute(CLASSNAME_ATTRIBUTE, testCase.getClassName());
+
+        String exceptionMessage = testCase.getExceptionMessage();
+        switch (testCase.getResult()) {
+          case SKIPPED:
+            Element skippedElement = document.createElement(SKIPPED_TAG);
+            testCaseElement.appendChild(skippedElement);
+            break;
+          case ERROR:
+            Element errorElement = document.createElement(ERROR_TAG);
+            errorElement.setTextContent(exceptionMessage);
+            testCaseElement.appendChild(errorElement);
+            break;
+          case FAILURE:
+            Element failureElement = document.createElement(FAILURE_TAG);
+            failureElement.setTextContent(exceptionMessage);
+            testCaseElement.appendChild(failureElement);
+            break;
+          default:
+            break;
+        }
+
+        testSuiteElement.appendChild(testCaseElement);
+      }
+    }
+
+    try {
+      Transformer transformer = TransformerFactory.newInstance().newTransformer();
+      BufferedWriter outputStream = Files.newBufferedWriter(outputFile, Charset.forName("UTF-8"));
+
+      StreamResult result = new StreamResult(outputStream);
+
+      transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+      transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+
+      transformer.transform(new DOMSource(document), result);
+    } catch (Exception e) {
+      throw new XmlReportGenerationException(e);
+    }
+
+    System.out.println("XML report written to: " + outputFile.toString());
+  }
+
+  public TestSuite readFromFile(Path filePath) {
+    List<TestCase> results = new ArrayList<>();
+    String shardName = extractShardName(filePath);
+    String matrixName = extractMatrixName(filePath);
+    Document document = XMLUtils.getXMLFile(filePath.toFile().getAbsolutePath());
+
+    NodeList nodes = document.getElementsByTagName(TESTCASE_TAG);
+
+    for (int i = 0; i < nodes.getLength(); i++) {
+      Node node = nodes.item(i);
+      if (node instanceof Element) {
+        Element testCase = (Element) node;
+
+        String testName = testCase.getAttribute(NAME_ATTRIBUTE);
+        String className = testCase.getAttribute(CLASSNAME_ATTRIBUTE);
+
+        boolean hasChildNodes = testCase.hasChildNodes();
+        if (hasChildNodes) {
+
+          Node firstElement = null;
+
+          NodeList childNodes = testCase.getChildNodes();
+          for (int j = 0; j < childNodes.getLength(); j++) {
+            Node item = childNodes.item(j);
+            if (item.getNodeType() == Node.ELEMENT_NODE) {
+              firstElement = item;
+              break;
+            }
+          }
+
+          if (firstElement == null) {
+            throw new IllegalStateException();
+          }
+
+          String message = firstElement.getTextContent().trim();
+          switch (firstElement.getNodeName()) {
+            case FAILURE_TAG:
+              results.add(TestCase.failure(shardName, testName, className, message));
+              break;
+            case ERROR_TAG:
+              results.add(TestCase.error(shardName, testName, className, message));
+              break;
+            case SKIPPED_TAG:
+              results.add(TestCase.skipped(shardName, testName, className));
+            default:
+              throw new IllegalStateException("Unable to process element: " + firstElement);
+          }
+        } else {
+          results.add(TestCase.success(shardName, testName, className));
+        }
+      }
+    }
+
+    NodeList elements = document.getElementsByTagName(TESTSUITE_TAG);
+    Element testSuite = (Element) elements.item(0);
+
+    String testCount = testSuite.getAttribute(TESTS_ATTRIBUTE);
+    String failuresCount = testSuite.getAttribute(FAILURES_ATTRIBUTE);
+    String errorsCount = testSuite.getAttribute(ERRORS_ATTRIBUTE);
+    String skippedCount = testSuite.getAttribute(SKIPPED_ATTRIBUTE);
+    String duration = testSuite.getAttribute(TIME_ATTRIBUTE);
+
+    return new TestSuite(
+        matrixName,
+        Integer.parseInt(testCount),
+        Integer.parseInt(failuresCount),
+        Integer.parseInt(errorsCount),
+        Integer.parseInt(skippedCount),
+        Float.parseFloat(duration),
+        results);
+  }
+
+  @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
+  private String extractShardName(Path filePath) {
+    return filePath.getParent().getParent().getFileName().toString();
+  }
+
+  @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
+  private String extractMatrixName(Path filePath) {
+    return filePath.getParent().getFileName().toString();
+  }
+}

--- a/Flank/src/main/java/com/walmart/otto/aggregator/ReportsAggregator.java
+++ b/Flank/src/main/java/com/walmart/otto/aggregator/ReportsAggregator.java
@@ -97,7 +97,7 @@ public class ReportsAggregator {
   }
 
   private List<TestSuite> readTestSuites(Path reportsBaseDir) throws IOException {
-    return findReportFiles(reportsBaseDir).map(junitReport::readFromFile).collect(toList());
+    return findReportFiles(reportsBaseDir).map(junitReport::readTestSuite).collect(toList());
   }
 
   static Stream<Path> findReportFiles(Path reportsBaseDir) throws IOException {

--- a/Flank/src/main/java/com/walmart/otto/aggregator/ReportsAggregator.java
+++ b/Flank/src/main/java/com/walmart/otto/aggregator/ReportsAggregator.java
@@ -1,0 +1,110 @@
+package com.walmart.otto.aggregator;
+
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toList;
+
+import com.walmart.otto.configurator.Configurator;
+import com.walmart.otto.tools.GsutilTool;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Stream;
+
+public class ReportsAggregator {
+
+  private final JunitReport junitReport = new JunitReport();
+  private final HtmlReport htmlReport;
+  private final ArtifactsProcessor artifactsProcessor;
+  private final GsutilTool gsutilTool;
+  private final Configurator configurator;
+
+  public ReportsAggregator(Configurator configurator, GsutilTool gsutilTool) {
+    this.artifactsProcessor = new ArtifactsProcessor(configurator);
+    this.gsutilTool = gsutilTool;
+    this.configurator = configurator;
+    this.htmlReport = new HtmlReport(configurator);
+  }
+
+  public void aggregate(Path reportsBaseDir)
+      throws XmlReportGenerationException, HtmlReportGenerationException, IOException,
+          InterruptedException {
+    String baseUrl = generateCloudStorageReportsBaseUrl(reportsBaseDir);
+
+    System.out.println("Generating combined reports starting from: " + reportsBaseDir.toString());
+
+    List<TestSuite> testSuites = readTestSuites(reportsBaseDir);
+
+    Map<String, List<TestSuite>> map =
+        testSuites.stream().collect(groupingBy(TestSuite::getMatrixName));
+
+    for (Entry<String, List<TestSuite>> entry : map.entrySet()) {
+
+      String matrixName = entry.getKey();
+      List<TestSuite> suites = entry.getValue();
+
+      if (configurator.isGenerateAggregatedXmlReport()) {
+        Path xmlOutputFile = reportsBaseDir.resolve(matrixName + "_results.xml");
+
+        junitReport.generate(xmlOutputFile, suites);
+        gsutilTool.uploadAggregatedXmlFiles(reportsBaseDir.toFile());
+
+        System.out.println("XML report uploaded to: " + baseUrl + "/" + getFileName(xmlOutputFile));
+      }
+
+      if (configurator.isGenerateAggregatedHtmlReport()) {
+        Path htmlOutputFile = reportsBaseDir.resolve(matrixName + "_results.html");
+
+        suites
+            .stream()
+            .flatMap(testSuite -> testSuite.getTestCaseList().stream())
+            .filter(TestCase::isFailure)
+            .parallel()
+            .forEach(testCase -> processArtifacts(reportsBaseDir, matrixName, testCase));
+
+        htmlReport.generate(baseUrl, htmlOutputFile, suites);
+        gsutilTool.uploadAggregatedHtmlReports(reportsBaseDir.toFile());
+
+        System.out.println(
+            "HTML report uploaded to: " + baseUrl + "/" + getFileName(htmlOutputFile));
+      }
+    }
+  }
+
+  private String generateCloudStorageReportsBaseUrl(Path reportBaseDir) {
+    return "https://storage.cloud.google.com/"
+        + configurator.getProjectName()
+        + "/"
+        + getFileName(reportBaseDir);
+  }
+
+  //we know we are going to call this for existing files
+  @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
+  private static String getFileName(Path htmlOutputFile) {
+    return htmlOutputFile.getFileName().toString();
+  }
+
+  private void processArtifacts(Path reportBaseDir, String matrixName, TestCase testCase) {
+    try {
+      artifactsProcessor.generateArtifactsForTestCase(reportBaseDir, matrixName, testCase);
+    } catch (IOException | InterruptedException e) {
+      System.out.println("Can't process test artifacts for: " + testCase.getTestName());
+      throw new RuntimeException(e);
+    }
+  }
+
+  private List<TestSuite> readTestSuites(Path reportsBaseDir) throws IOException {
+    return findReportFiles(reportsBaseDir).map(junitReport::readFromFile).collect(toList());
+  }
+
+  static Stream<Path> findReportFiles(Path reportsBaseDir) throws IOException {
+    return Files.find(reportsBaseDir, 3, (path, basicFileAttributes) -> isTestReport(path));
+  }
+
+  static boolean isTestReport(Path path) {
+    return getFileName(path).startsWith("test_result_");
+  }
+}

--- a/Flank/src/main/java/com/walmart/otto/aggregator/Result.java
+++ b/Flank/src/main/java/com/walmart/otto/aggregator/Result.java
@@ -1,0 +1,8 @@
+package com.walmart.otto.aggregator;
+
+public enum Result {
+  SUCCESS,
+  FAILURE,
+  ERROR,
+  SKIPPED
+}

--- a/Flank/src/main/java/com/walmart/otto/aggregator/TestCase.java
+++ b/Flank/src/main/java/com/walmart/otto/aggregator/TestCase.java
@@ -1,0 +1,72 @@
+package com.walmart.otto.aggregator;
+
+class TestCase {
+
+  private final String shardName;
+  private final String testName;
+  private final String className;
+  private final String exceptionMessage;
+  private final Result result;
+  private final String id;
+
+  private TestCase(
+      Result result, String shardName, String testName, String className, String exceptionMessage) {
+    this.result = result;
+    this.shardName = shardName;
+    this.testName = testName;
+    this.className = className;
+    this.exceptionMessage = exceptionMessage;
+    this.id = generateTestId(testName, className);
+  }
+
+  static String generateTestId(String testName, String className) {
+    final String[] tokens = className.split("\\.");
+    return tokens[tokens.length - 1] + "_" + testName;
+  }
+
+  static TestCase success(String shardName, String testName, String className) {
+    return new TestCase(Result.SUCCESS, shardName, testName, className, null);
+  }
+
+  static TestCase failure(
+      String shardName, String testName, String className, String exceptionMessage) {
+    return new TestCase(Result.FAILURE, shardName, testName, className, exceptionMessage);
+  }
+
+  static TestCase error(
+      String shardName, String testName, String className, String exceptionMessage) {
+    return new TestCase(Result.ERROR, shardName, testName, className, exceptionMessage);
+  }
+
+  static TestCase skipped(String shardName, String testName, String className) {
+    return new TestCase(Result.SKIPPED, shardName, testName, className, null);
+  }
+
+  public boolean isFailure() {
+    return result == Result.FAILURE;
+  }
+
+  public String getTestName() {
+    return testName;
+  }
+
+  public String getExceptionMessage() {
+    return exceptionMessage;
+  }
+
+  public String getClassName() {
+    return className;
+  }
+
+  public String getShardName() {
+    return shardName;
+  }
+
+  public Result getResult() {
+    return result;
+  }
+
+  public String getId() {
+    return id;
+  }
+}

--- a/Flank/src/main/java/com/walmart/otto/aggregator/TestClass.java
+++ b/Flank/src/main/java/com/walmart/otto/aggregator/TestClass.java
@@ -1,0 +1,37 @@
+package com.walmart.otto.aggregator;
+
+import java.util.List;
+
+public class TestClass {
+
+  private final String name;
+  private final List<TestCase> testCases;
+
+  private final long failingTestsCount;
+
+  public TestClass(List<TestCase> testCases) {
+    this.testCases = testCases;
+    this.failingTestsCount = testCases.stream().filter(TestCase::isFailure).count();
+    this.name = testCases.stream().findFirst().map(TestCase::getClassName).orElse(null);
+  }
+
+  public List<TestCase> getTestCases() {
+    return testCases;
+  }
+
+  public long getFailingTestsCount() {
+    return failingTestsCount;
+  }
+
+  public boolean hasFailure() {
+    return failingTestsCount > 0;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public int getCount() {
+    return testCases.size();
+  }
+}

--- a/Flank/src/main/java/com/walmart/otto/aggregator/TestSuite.java
+++ b/Flank/src/main/java/com/walmart/otto/aggregator/TestSuite.java
@@ -1,0 +1,59 @@
+package com.walmart.otto.aggregator;
+
+import java.util.List;
+
+public class TestSuite {
+
+  private final String matrixName;
+  private final int testsCount;
+  private final int failuresCount;
+  private final int errorsCount;
+  private final int skippedCount;
+  private final float durantion;
+  private final List<TestCase> testCaseList;
+
+  public TestSuite(
+      String matrixName,
+      int testsCount,
+      int failuresCount,
+      int errorsCount,
+      int skippedCount,
+      float durantion,
+      List<TestCase> testCaseList) {
+    this.matrixName = matrixName;
+    this.testsCount = testsCount;
+    this.failuresCount = failuresCount;
+    this.errorsCount = errorsCount;
+    this.skippedCount = skippedCount;
+    this.durantion = durantion;
+    this.testCaseList = testCaseList;
+  }
+
+  public int getTestsCount() {
+    return testsCount;
+  }
+
+  public int getFailuresCount() {
+    return failuresCount;
+  }
+
+  public int getSkippedCount() {
+    return skippedCount;
+  }
+
+  public float getDurantion() {
+    return durantion;
+  }
+
+  public List<TestCase> getTestCaseList() {
+    return testCaseList;
+  }
+
+  public int getErrorsCount() {
+    return errorsCount;
+  }
+
+  public String getMatrixName() {
+    return matrixName;
+  }
+}

--- a/Flank/src/main/java/com/walmart/otto/aggregator/TimeUtils.java
+++ b/Flank/src/main/java/com/walmart/otto/aggregator/TimeUtils.java
@@ -1,0 +1,14 @@
+package com.walmart.otto.aggregator;
+
+import java.time.Duration;
+
+class TimeUtils {
+
+  static String formatDuration(Duration duration) {
+    long seconds = duration.getSeconds();
+    if (seconds < 0) {
+      throw new IllegalArgumentException("invalid negative duration");
+    }
+    return String.format("%02d:%02d:%02d", seconds / 3600, (seconds % 3600) / 60, seconds % 60);
+  }
+}

--- a/Flank/src/main/java/com/walmart/otto/aggregator/XmlReportGenerationException.java
+++ b/Flank/src/main/java/com/walmart/otto/aggregator/XmlReportGenerationException.java
@@ -1,0 +1,8 @@
+package com.walmart.otto.aggregator;
+
+public class XmlReportGenerationException extends Exception {
+
+  public XmlReportGenerationException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/Flank/src/main/java/com/walmart/otto/configurator/ConfigReader.java
+++ b/Flank/src/main/java/com/walmart/otto/configurator/ConfigReader.java
@@ -1,12 +1,15 @@
 package com.walmart.otto.configurator;
 
 import com.walmart.otto.models.Device;
-import java.io.*;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Properties;
 
 public class ConfigReader {
-  Configurator configurator;
+
+  private Configurator configurator;
   private String fileName;
 
   public ConfigReader(String fileName, Configurator configurator) throws IllegalArgumentException {
@@ -120,6 +123,22 @@ public class ConfigReader {
 
       case "skip-tests":
         configurator.setSkipTests(Arrays.asList(value.split(",")));
+        break;
+
+      case "aggregate-reports.enabled":
+        configurator.setAggregateReportsEnabled(Boolean.parseBoolean(value));
+        break;
+
+      case "aggregate-reports.xml":
+        configurator.setGenerateAggregatedXmlReport(Boolean.parseBoolean(value));
+        break;
+
+      case "aggregate-reports.html":
+        configurator.setGenerateAggregatedHtmlReport(Boolean.parseBoolean(value));
+        break;
+
+      case "aggregate-reports.split-video":
+        configurator.setGenerateSplitVideo(Boolean.parseBoolean(value));
         break;
 
       default:

--- a/Flank/src/main/java/com/walmart/otto/configurator/Configurator.java
+++ b/Flank/src/main/java/com/walmart/otto/configurator/Configurator.java
@@ -29,6 +29,11 @@ public class Configurator {
   private int shardTimeout = 5;
   private int shardDuration = 120;
 
+  private boolean aggregateReportsEnabled = false;
+  private boolean generateAggregatedXmlReport = true;
+  private boolean generateAggregatedHtmlReport = true;
+  private boolean generateSplitVideo = false;
+
   public Configurator() {
     setupDevices();
   }
@@ -214,5 +219,37 @@ public class Configurator {
         }
       }
     }
+  }
+
+  public void setAggregateReportsEnabled(boolean aggregateReportsEnabled) {
+    this.aggregateReportsEnabled = aggregateReportsEnabled;
+  }
+
+  public boolean isAggregateReportsEnabled() {
+    return aggregateReportsEnabled;
+  }
+
+  public boolean isGenerateAggregatedXmlReport() {
+    return generateAggregatedXmlReport;
+  }
+
+  public void setGenerateAggregatedXmlReport(boolean generateAggregatedXmlReport) {
+    this.generateAggregatedXmlReport = generateAggregatedXmlReport;
+  }
+
+  public boolean isGenerateAggregatedHtmlReport() {
+    return generateAggregatedHtmlReport;
+  }
+
+  public void setGenerateAggregatedHtmlReport(boolean generateAggregatedHtmlReport) {
+    this.generateAggregatedHtmlReport = generateAggregatedHtmlReport;
+  }
+
+  public boolean isGenerateSplitVideo() {
+    return generateSplitVideo;
+  }
+
+  public void setGenerateSplitVideo(boolean generateSplitVideo) {
+    this.generateSplitVideo = generateSplitVideo;
   }
 }

--- a/Flank/src/main/resources/tests_results.mustache
+++ b/Flank/src/main/resources/tests_results.mustache
@@ -1,0 +1,114 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <title>Tests result</title>
+  <!-- Required meta tags -->
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+  <!-- Bootstrap CSS -->
+  <link rel="stylesheet"
+        href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.2/css/bootstrap.min.css"
+        integrity="sha384-PsH8R72JQ3SOdhVi3uxftmaW6Vc51MKb0q5P2rRUpPvrszuE4W1povHYgTpBfshb"
+        crossorigin="anonymous">
+
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons"
+        rel="stylesheet">
+
+  <style>
+body { padding-top: 50px; }
+
+.main-container { padding: 3rem 12rem; }
+
+.test-class-name { height: 24px; }
+.test-class-name > span { line-height: 24px; vertical-align: middle; }
+.test-class-name > i { vertical-align: middle; }
+
+.material-icons.danger { color: rgba(217, 83, 79, 1); }
+.material-icons.success { color: rgba(92, 184, 92, 1); }
+  </style>
+</head>
+<body>
+
+<nav class="navbar fixed-top navbar-light bg-light">
+  {{#failed}}
+    <a class="navbar-brand">Tests result: {{failuresCount}} over {{testsCount}} tests are
+      failing 🔥</a>
+  {{/failed}}
+  {{^failed}}
+    <a class="navbar-brand">Tests result: All {{testsCount}} tests passed 🚀</a>
+  {{/failed}}
+  <span class="navbar-text">
+    Run time: {{duration}} on {{shardsCount}} emulators
+  </span>
+</nav>
+
+<main role="main" class="container-fluid">
+  <div class="main-container">
+    {{#testClasses}}
+    <div style="margin-bottom: 24px">
+      {{#hasFailure}}
+        <div class="test-class-name">
+          <span class="h5" data-toggle="collapse" data-target="#collapse{{-index}}"
+          aria-controls="collapse{{-index}}">{{name}}
+          </span>
+          <b class="badge badge-pill badge-danger">{{failingTestsCount}}/{{count}}</b>
+        </div>
+      <div class="collapse show" id="collapse{{-index}}">
+      {{/hasFailure}}
+      {{^hasFailure}}
+        <div class="test-class-name">
+          <span class="h5" data-toggle="collapse" data-target="#collapse{{-index}}"
+          aria-controls="collapse{{-index}}">{{name}}
+          </span>
+          <b class="badge badge-pill badge-success">{{count}}</b>
+        </div>
+      <div class="collapse" id="collapse{{-index}}">
+      {{/hasFailure}}
+
+      <div class="card" style="margin-top:24px">
+        <ul class="list-group list-group-flush">
+          {{#testCases}}
+
+            {{#isFailure}}
+              <li class="list-group-item">
+                <p class="card-text text-danger">{{testName}}
+                  <b class="badge badge-pill badge-light">Shard: {{shardName}}</b>
+                </p>
+                <pre class="card-text scrollable">{{exceptionMessage}}</pre>
+                <a href="{{baseUrl}}/logcat/{{id}}.txt" class="btn btn-outline-primary">Test Logcat</a>
+                {{#splitVideo}}
+                <a href="{{baseUrl}}/video/{{id}}.mp4" class="btn btn-outline-primary">Test Video (approx.)</a>
+                {{/splitVideo}}
+                <a href="{{baseUrl}}/logcat/shard_{{shardName}}.txt" class="btn btn-outline-secondary">Shard Logcat</a>
+                <a href="{{baseUrl}}/video/shard_{{shardName}}.mp4" class="btn btn-outline-secondary">Shard Video</a>
+              </li>
+            {{/isFailure}}
+
+            {{^isFailure}}
+              <li class="list-group-item">
+                <p class="card-text text-success">{{testName}}
+                  <b class="badge badge-pill badge-light">Shard: {{shardName}}</b>
+                </p>
+              </li>
+            {{/isFailure}}
+          {{/testCases}}
+        </ul>
+      </div>
+    </div>
+    </div>
+    {{/testClasses}}
+  </div>
+</main>
+
+<script src="https://code.jquery.com/jquery-3.2.1.slim.min.js"
+        integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN"
+        crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.3/umd/popper.min.js"
+        integrity="sha384-vFJXuSJphROIrBnz7yo7oB41mKfc8JzQZiCq4NCceLEaO4IHwicKwpJf9c9IpFgh"
+        crossorigin="anonymous"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.2/js/bootstrap.min.js"
+        integrity="sha384-alpBpkh1PFOepccYVYDB4do5UnbKysX5WZXm3XxPqe5iKTfUKjNkCk9SaVuEZflJ"
+        crossorigin="anonymous"></script>
+</body>
+</html>

--- a/Flank/src/main/resources/tests_results.mustache
+++ b/Flank/src/main/resources/tests_results.mustache
@@ -32,7 +32,7 @@ body { padding-top: 50px; }
 
 <nav class="navbar fixed-top navbar-light bg-light">
   {{#failed}}
-    <a class="navbar-brand">Tests result: {{failuresCount}} over {{testsCount}} tests are
+    <a class="navbar-brand">Tests result: {{failuresCount}} of {{testsCount}} tests are
       failing 🔥</a>
   {{/failed}}
   {{^failed}}

--- a/Flank/src/test/java/com/walmart/otto/aggregator/Fixtures.java
+++ b/Flank/src/test/java/com/walmart/otto/aggregator/Fixtures.java
@@ -1,0 +1,31 @@
+package com.walmart.otto.aggregator;
+
+import java.util.Collections;
+import org.jetbrains.annotations.NotNull;
+
+class Fixtures {
+
+  @NotNull
+  static TestSuite suiteWithoutFailure() {
+    return new TestSuite(
+        "matrixName",
+        1,
+        0,
+        0,
+        0,
+        123,
+        Collections.singletonList(TestCase.success("1", "testSuccess", "ClassName")));
+  }
+
+  @NotNull
+  static TestSuite suiteWithFailure() {
+    return new TestSuite(
+        "matrixName",
+        1,
+        1,
+        0,
+        0,
+        123,
+        Collections.singletonList(TestCase.failure("1", "testFailure", "ClassName", "stacktrace")));
+  }
+}

--- a/Flank/src/test/java/com/walmart/otto/aggregator/JunitReportTest.java
+++ b/Flank/src/test/java/com/walmart/otto/aggregator/JunitReportTest.java
@@ -1,0 +1,61 @@
+package com.walmart.otto.aggregator;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import com.walmart.otto.testsupport.TestUtils;
+import com.walmart.otto.testsupport.XmlUtils;
+import java.nio.file.Path;
+import java.util.Arrays;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class JunitReportTest {
+
+  @Rule public TemporaryFolder folder = new TemporaryFolder();
+
+  private JunitReport junitReport;
+
+  @Before
+  public void setUp() throws Exception {
+    junitReport = new JunitReport();
+  }
+
+  @Test
+  public void shouldProperlyReadTestSuiteFromFile() throws Exception {
+    Path reportPath = TestUtils.readFileFromResources("test_report_with_failures.xml");
+
+    TestSuite testSuite = junitReport.readFromFile(reportPath);
+    assertThat(testSuite.getFailuresCount(), equalTo(1));
+    assertThat(testSuite.getTestsCount(), equalTo(4));
+    assertThat(testSuite.getDurantion(), equalTo(123.0F));
+
+    long failingTestCasesCount =
+        testSuite.getTestCaseList().stream().filter(TestCase::isFailure).count();
+    assertThat(failingTestCasesCount, equalTo(1L));
+
+    TestCase failure =
+        testSuite.getTestCaseList().stream().filter(TestCase::isFailure).findFirst().get();
+
+    assertThat(failure.getExceptionMessage(), equalTo("stacktrace"));
+    assertThat(failure.getTestName(), equalTo("test1"));
+    assertThat(failure.getClassName(), equalTo("com.foo.Class"));
+  }
+
+  @Test
+  public void shouldGenerateAggregateReportFromTestSuites() throws Exception {
+    TestSuite firstTestSuite = Fixtures.suiteWithoutFailure();
+    TestSuite secondTestSuite = Fixtures.suiteWithFailure();
+
+    Path outputFile = folder.newFile().toPath();
+
+    junitReport.generate(outputFile, Arrays.asList(firstTestSuite, secondTestSuite));
+
+    Path expectedFile = TestUtils.readFileFromResources("combined_test_report.xml");
+
+    assertThat(XmlUtils.haveSameContent(outputFile, expectedFile), is(true));
+  }
+}

--- a/Flank/src/test/java/com/walmart/otto/aggregator/JunitReportTest.java
+++ b/Flank/src/test/java/com/walmart/otto/aggregator/JunitReportTest.java
@@ -28,7 +28,7 @@ public class JunitReportTest {
   public void shouldProperlyReadTestSuiteFromFile() throws Exception {
     Path reportPath = TestUtils.readFileFromResources("test_report_with_failures.xml");
 
-    TestSuite testSuite = junitReport.readFromFile(reportPath);
+    TestSuite testSuite = junitReport.readTestSuite(reportPath);
     assertThat(testSuite.getFailuresCount(), equalTo(1));
     assertThat(testSuite.getTestsCount(), equalTo(4));
     assertThat(testSuite.getDurantion(), equalTo(123.0F));

--- a/Flank/src/test/java/com/walmart/otto/aggregator/ReportsAggregatorTest.java
+++ b/Flank/src/test/java/com/walmart/otto/aggregator/ReportsAggregatorTest.java
@@ -1,0 +1,49 @@
+package com.walmart.otto.aggregator;
+
+import static com.walmart.otto.aggregator.ReportsAggregator.isTestReport;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+
+import com.walmart.otto.testsupport.TestUtils;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class ReportsAggregatorTest {
+
+  @Rule public TemporaryFolder folder = new TemporaryFolder();
+
+  @Test
+  public void findReportFiles() throws Exception {
+    Path reports = TestUtils.readFileFromResources("reports");
+
+    List<Path> pathList = ReportsAggregator.findReportFiles(reports).collect(Collectors.toList());
+    assertThat(pathList.size(), equalTo(2));
+
+    Path first = TestUtils.readFileFromResources("reports/0/test_result_0.xml");
+    Path second = TestUtils.readFileFromResources("reports/1/test_result_0.xml");
+    Path third = TestUtils.readFileFromResources("reports/2/file.txt");
+
+    assertThat(pathList, hasItems(first, second));
+    assertThat(pathList, not(hasItem(third)));
+  }
+
+  @Test
+  public void shouldMatchXmlReportName() throws Exception {
+    Path stubFile = folder.newFile("test_result_0.xml").toPath();
+    assertThat(isTestReport(stubFile), is(true));
+  }
+
+  @Test
+  public void shouldNotMatchOtherFiles() throws Exception {
+    Path stubFile = folder.newFile("logcat").toPath();
+    assertThat(isTestReport(stubFile), is(false));
+  }
+}

--- a/Flank/src/test/java/com/walmart/otto/aggregator/TestCaseTest.java
+++ b/Flank/src/test/java/com/walmart/otto/aggregator/TestCaseTest.java
@@ -1,0 +1,15 @@
+package com.walmart.otto.aggregator;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class TestCaseTest {
+
+  @Test
+  public void shouldGenerateIdWithClassNameAndTestname() throws Exception {
+    String testId = TestCase.generateTestId("testName", "com.foo.Bar");
+    assertThat(testId, equalTo("Bar_testName"));
+  }
+}

--- a/Flank/src/test/java/com/walmart/otto/aggregator/TimeUtilsTest.java
+++ b/Flank/src/test/java/com/walmart/otto/aggregator/TimeUtilsTest.java
@@ -1,0 +1,21 @@
+package com.walmart.otto.aggregator;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.time.Duration;
+import org.junit.Test;
+
+public class TimeUtilsTest {
+
+  @Test
+  public void shouldFormatDurationInTheFullFormat() throws Exception {
+    String duration = TimeUtils.formatDuration(Duration.ofSeconds(3600 + 60 + 5));
+    assertThat(duration, equalTo("01:01:05"));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldThrowOnNegativeDuration() throws Exception {
+    TimeUtils.formatDuration(Duration.ofSeconds(-10));
+  }
+}

--- a/Flank/src/test/java/com/walmart/otto/testsupport/TestUtils.java
+++ b/Flank/src/test/java/com/walmart/otto/testsupport/TestUtils.java
@@ -1,0 +1,13 @@
+package com.walmart.otto.testsupport;
+
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class TestUtils {
+  public static Path readFileFromResources(String name) throws URISyntaxException {
+    URL resource = TestUtils.class.getClassLoader().getResource(name);
+    return Paths.get(resource.toURI());
+  }
+}

--- a/Flank/src/test/java/com/walmart/otto/testsupport/XmlUtils.java
+++ b/Flank/src/test/java/com/walmart/otto/testsupport/XmlUtils.java
@@ -1,0 +1,30 @@
+package com.walmart.otto.testsupport;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+
+public class XmlUtils {
+
+  public static boolean haveSameContent(Path first, Path second)
+      throws ParserConfigurationException, IOException, SAXException {
+    DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+    dbf.setNamespaceAware(true);
+    dbf.setCoalescing(true);
+    dbf.setIgnoringElementContentWhitespace(true);
+    dbf.setIgnoringComments(true);
+    DocumentBuilder db = dbf.newDocumentBuilder();
+
+    Document doc1 = db.parse(first.toFile());
+    doc1.normalizeDocument();
+
+    Document doc2 = db.parse(second.toFile());
+    doc2.normalizeDocument();
+
+    return doc1.isEqualNode(doc2);
+  }
+}

--- a/Flank/src/test/resources/combined_test_report.xml
+++ b/Flank/src/test/resources/combined_test_report.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<testsuite errors="0" failures="1" hostname="localhost" skipped="0" tests="2" time="246.00">
+  <testcase classname="ClassName" name="testSuccess"/>
+  <testcase classname="ClassName" name="testFailure">
+    <failure>stacktrace</failure>
+  </testcase>
+</testsuite>

--- a/Flank/src/test/resources/reports/0/test_result_0.xml
+++ b/Flank/src/test/resources/reports/0/test_result_0.xml
@@ -1,0 +1,1 @@
+#placeholder

--- a/Flank/src/test/resources/reports/1/test_result_0.xml
+++ b/Flank/src/test/resources/reports/1/test_result_0.xml
@@ -1,0 +1,1 @@
+#placeholder

--- a/Flank/src/test/resources/reports/2/file.txt
+++ b/Flank/src/test/resources/reports/2/file.txt
@@ -1,0 +1,1 @@
+#placeholder

--- a/Flank/src/test/resources/test_report_with_failures.xml
+++ b/Flank/src/test/resources/test_report_with_failures.xml
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' ?>
 <testsuite name="" tests="4" failures="1" errors="0" skipped="0" time="123" timestamp="2017-11-21T15:29:56" hostname="localhost">
-  <properties />
   <testcase name="test1" classname="com.foo.Class" time="0.0">
     <failure>
       stacktrace

--- a/Flank/src/test/resources/test_report_with_failures.xml
+++ b/Flank/src/test/resources/test_report_with_failures.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<testsuite name="" tests="4" failures="1" errors="0" skipped="0" time="123" timestamp="2017-11-21T15:29:56" hostname="localhost">
+  <properties />
+  <testcase name="test1" classname="com.foo.Class" time="0.0">
+    <failure>
+      stacktrace
+    </failure>
+  </testcase>
+  <testcase name="test2" classname="com.foo.Class" time="0.0" />
+  <testcase name="test3" classname="com.foo.Class" time="0.0" />
+  <testcase name="test4" classname="com.foo.Class" time="0.0" />
+</testsuite>

--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ gsutil-path: The path to the gsutil binary
 gcloud-bucket: The Google Cloud Storage bucket to use. If not specified Flank will create one.
 use-gcloud-beta: If gcloud beta should be used
 
+aggregate-reports.enabled: Enable the experimental test aggregation feature. Requires fetch-bucket to be enabled. Disabled by default.
+aggregate-reports.xml: Generates and pushes to Google Cloud Storage an aggregated XML report
+aggregate-reports.html: Generates and pushes to Google Cloud Storage an aggregated HTML report, including Logcat and video for the failing tests
+aggregate-reports.split-video: For failing test cases, attempts to split the execution video to capture only the failing test and includes a link in the HTML report. Requires ffmpeg to be installed
+
 deviceIds: The ID:s of the devices to run the tests on (deprecated, should not be used in conjunction with `device`)
 os-version-ids: The API-levels of the devices to run the tests on (deprecated, should not be used in conjunction with `device`)
 orientations: The orientations, portrait, landscape or both (deprecated, should not be used in conjunction with `device`)
@@ -84,6 +89,9 @@ fetch-xml-files=true
 fetch-bucket=true
 gcloud-path=
 gsutil-path=
+aggregate-reports.enabled=true
+aggregate-reports.xml=true
+aggregate-reports.html=true
 ```
 
 ### Configurable Shards


### PR DESCRIPTION
This PR introduces a new (experimental) feature in Flank: _Test reports aggregation_. 

After each build Flank will generates, starting from the previously fetched bucket, a combined XML and HTML report and pushes them back to the GCS bucket.  The HTML report includes links to  Logcat and Video for both the single test and the entire shard. 

**HTML report in case of failing build**
![screenshot  build failure](https://user-images.githubusercontent.com/245528/33427126-811c24c4-d5c4-11e7-84ec-42afe683e0f7.png)

**HTML report in case of successful build**
![screenshot build success](https://user-images.githubusercontent.com/245528/33427128-81675d86-d5c4-11e7-9721-c2a0cc1e90d8.png)

The feature is experimental and thus requires to be explicitly turned on. The idea is to gather feedbacks and fix potential issues.