### PR TITLE
Trim arguments test filters after splitting

### DIFF
--- a/Flank/src/main/java/com/walmart/otto/filter/TestFilters.java
+++ b/Flank/src/main/java/com/walmart/otto/filter/TestFilters.java
@@ -45,7 +45,9 @@ public class TestFilters {
     boolean isNegate = matcher.group(1) != null;
 
     Collection<String> args =
-        Arrays.stream(matcher.group(3).split(",")).collect(Collectors.toSet());
+        Arrays.stream(matcher.group(3).split(","))
+            .map(String::trim) //splitting by comma will leave leading or trailing spaces
+            .collect(Collectors.toSet());
 
     String command = matcher.group(2).toLowerCase();
 

--- a/Flank/src/test/java/com/walmart/otto/filter/TestFiltersTest.java
+++ b/Flank/src/test/java/com/walmart/otto/filter/TestFiltersTest.java
@@ -7,6 +7,7 @@ import static com.walmart.otto.filter.TestMethodFixtures.FOO_CLASSNAME;
 import static com.walmart.otto.filter.TestMethodFixtures.FOO_PACKAGE;
 import static com.walmart.otto.filter.TestMethodFixtures.WITHOUT_FOO_ANNOTATION;
 import static com.walmart.otto.filter.TestMethodFixtures.WITHOUT_IGNORE_ANNOTATION;
+import static com.walmart.otto.filter.TestMethodFixtures.WITH_BAR_ANNOTATION;
 import static com.walmart.otto.filter.TestMethodFixtures.WITH_FOO_ANNOTATION;
 import static com.walmart.otto.filter.TestMethodFixtures.WITH_FOO_ANNOTATION_AND_PACKAGE;
 import static com.walmart.otto.filter.TestMethodFixtures.WITH_IGNORE_ANNOTATION;
@@ -64,6 +65,7 @@ public class TestFiltersTest {
     TestFilter filter = TestFilters.fromCommandLineArguments("annotation Foo,Bar");
 
     assertTrue(filter.shouldRun(WITH_FOO_ANNOTATION));
+    assertTrue(filter.shouldRun(WITH_BAR_ANNOTATION));
     assertFalse(filter.shouldRun(WITHOUT_FOO_ANNOTATION));
   }
 
@@ -72,6 +74,7 @@ public class TestFiltersTest {
     TestFilter filter = TestFilters.fromCommandLineArguments("annotation Foo, Bar");
 
     assertTrue(filter.shouldRun(WITH_FOO_ANNOTATION));
+    assertTrue(filter.shouldRun(WITH_BAR_ANNOTATION));
     assertFalse(filter.shouldRun(WITHOUT_FOO_ANNOTATION));
   }
 

--- a/Flank/src/test/java/com/walmart/otto/filter/TestMethodFixtures.java
+++ b/Flank/src/test/java/com/walmart/otto/filter/TestMethodFixtures.java
@@ -24,6 +24,9 @@ public class TestMethodFixtures {
   static final TestMethod WITH_FOO_ANNOTATION =
       new TestMethod("whatever.Foo#testName", singletonList("Foo"));
 
+  static final TestMethod WITH_BAR_ANNOTATION =
+      new TestMethod("whatever.Foo#testName", singletonList("Bar"));
+
   static final TestMethod WITHOUT_FOO_ANNOTATION =
       new TestMethod("whatever.Foo#testName", emptyList());
 


### PR DESCRIPTION
This PR fix an issue in which passing the values separated by comma followed by space would not work properly.