### PR TITLE
Cloud testing updates

### DIFF
--- a/cloud_testing/apis/testing_v1_swagger_2.json
+++ b/cloud_testing/apis/testing_v1_swagger_2.json
@@ -1,0 +1,1630 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "v1",
+    "title": "Google Cloud Testing API",
+    "description": "Allows developers to run automated tests for their mobile applications on Google infrastructure.",
+    "license": {
+      "name": "MIT",
+      "url": "http://github.com/gruntjs/grunt/blob/master/LICENSE-MIT"
+    }
+  },
+  "host": "testing.googleapis.com",
+  "basePath": "/",
+  "securityDefinitions": {
+    "auth": {
+      "type": "oauth2",
+      "flow": "implicit",
+      "authorizationUrl": "https://testing.googleapis.com/",
+      "scopes": {
+        "https://www.googleapis.com/auth/cloud-platform": "View and manage your data across Google Cloud Platform services",
+        "https://www.googleapis.com/auth/cloud-platform.read-only": "View your data across Google Cloud Platform services"
+      },
+      "x-skip-client-authentication": false
+    }
+  },
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/v1/testEnvironmentCatalog/{environmentType}": {
+      "get": {
+        "description": "Get the catalog of supported test environments.\n\nMay return any of the following canonical error codes:\n\n- INVALID_ARGUMENT - if the request is malformed\n- NOT_FOUND - if the environment type does not exist\n- INTERNAL - if an internal error occurred",
+        "summary": "GetV1TestEnvironmentCatalog",
+        "tags": [
+          "testEnvironmentCatalog"
+        ],
+        "operationId": "V1TestEnvironmentCatalogByEnvironmentTypeGet",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "environmentType",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The type of environment that should be listed.\nRequired (Acceptable values are: \"ENVIRONMENT_TYPE_UNSPECIFIED\", \"ANDROID\", \"NETWORK_CONFIGURATION\")"
+          },
+          {
+            "name": "access_token",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "OAuth access token."
+          },
+          {
+            "name": "alt",
+            "in": "query",
+            "required": false,
+            "default": "json",
+            "type": "string",
+            "description": "Data format for response. (Acceptable values are: \"json\", \"media\", \"proto\")"
+          },
+          {
+            "name": "bearer_token",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "OAuth bearer token."
+          },
+          {
+            "name": "callback",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "JSONP"
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Selector specifying which fields to include in a partial response."
+          },
+          {
+            "name": "key",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token."
+          },
+          {
+            "name": "oauth_token",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "OAuth 2.0 token for the current user."
+          },
+          {
+            "name": "pp",
+            "in": "query",
+            "required": false,
+            "default": true,
+            "type": "boolean",
+            "description": "Pretty-print response."
+          },
+          {
+            "name": "prettyPrint",
+            "in": "query",
+            "required": false,
+            "default": true,
+            "type": "boolean",
+            "description": "Returns response with indentations and line breaks."
+          },
+          {
+            "name": "quotaUser",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters."
+          },
+          {
+            "name": "upload_protocol",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Upload protocol for media (e.g. \"raw\", \"multipart\")."
+          },
+          {
+            "name": "uploadType",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Legacy upload protocol for media (e.g. \"media\", \"multipart\")."
+          },
+          {
+            "name": "$.xgafv",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "V1 error format. (Acceptable values are: \"1\", \"2\")"
+          },
+          {
+            "name": "projectId",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "For authorization, the cloud project requesting the TestEnvironmentCatalog.\nOptional"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/TestEnvironmentCatalog"
+            },
+            "examples": {}
+          }
+        },
+        "security": [
+          {
+            "auth": [
+              "https://www.googleapis.com/auth/cloud-platform",
+              "https://www.googleapis.com/auth/cloud-platform.read-only"
+            ]
+          }
+        ],
+        "x-unitTests": [],
+        "x-operation-settings": {
+          "CollectParameters": false,
+          "AllowDynamicQueryParameters": false,
+          "AllowDynamicFormParameters": false,
+          "IsMultiContentStreaming": false
+        }
+      }
+    },
+    "/v1/projects/{projectId}/testMatrices": {
+      "post": {
+        "description": "Request to run a matrix of tests according to the given specifications.\nUnsupported environments will be returned in the state UNSUPPORTED.\nMatrices are limited to at most 200 supported executions.\n\nMay return any of the following canonical error codes:\n\n- PERMISSION_DENIED - if the user is not authorized to write to project\n- INVALID_ARGUMENT - if the request is malformed or if the matrix expands\n                     to more than 200 supported executions",
+        "summary": "CreateV1ProjectsTestMatricesByProjectId",
+        "tags": [
+          "testMatrices"
+        ],
+        "operationId": "V1ProjectsTestMatricesByProjectIdPost",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The GCE project under which this job will run."
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/TestMatrix"
+            }
+          },
+          {
+            "name": "access_token",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "OAuth access token."
+          },
+          {
+            "name": "alt",
+            "in": "query",
+            "required": false,
+            "default": "json",
+            "type": "string",
+            "description": "Data format for response. (Acceptable values are: \"json\", \"media\", \"proto\")"
+          },
+          {
+            "name": "bearer_token",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "OAuth bearer token."
+          },
+          {
+            "name": "callback",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "JSONP"
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Selector specifying which fields to include in a partial response."
+          },
+          {
+            "name": "key",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token."
+          },
+          {
+            "name": "oauth_token",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "OAuth 2.0 token for the current user."
+          },
+          {
+            "name": "pp",
+            "in": "query",
+            "required": false,
+            "default": true,
+            "type": "boolean",
+            "description": "Pretty-print response."
+          },
+          {
+            "name": "prettyPrint",
+            "in": "query",
+            "required": false,
+            "default": true,
+            "type": "boolean",
+            "description": "Returns response with indentations and line breaks."
+          },
+          {
+            "name": "quotaUser",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters."
+          },
+          {
+            "name": "upload_protocol",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Upload protocol for media (e.g. \"raw\", \"multipart\")."
+          },
+          {
+            "name": "uploadType",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Legacy upload protocol for media (e.g. \"media\", \"multipart\")."
+          },
+          {
+            "name": "$.xgafv",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "V1 error format. (Acceptable values are: \"1\", \"2\")"
+          },
+          {
+            "name": "requestId",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "A string id used to detect duplicated requests.\nIds are automatically scoped to a project, so\nusers should ensure the ID is unique per-project.\nA UUID is recommended.\n\nOptional, but strongly recommended."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/TestMatrix"
+            },
+            "examples": {}
+          }
+        },
+        "security": [
+          {
+            "auth": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          }
+        ],
+        "x-unitTests": [],
+        "x-operation-settings": {
+          "CollectParameters": false,
+          "AllowDynamicQueryParameters": false,
+          "AllowDynamicFormParameters": false,
+          "IsMultiContentStreaming": false
+        }
+      }
+    },
+    "/v1/projects/{projectId}/testMatrices/{testMatrixId}": {
+      "get": {
+        "description": "Check the status of a test matrix.\n\nMay return any of the following canonical error codes:\n\n- PERMISSION_DENIED - if the user is not authorized to read project\n- INVALID_ARGUMENT - if the request is malformed\n- NOT_FOUND - if the Test Matrix does not exist",
+        "summary": "GetV1ProjectsTestMatricesByProjectId",
+        "tags": [
+          "testMatrices"
+        ],
+        "operationId": "V1ProjectsTestMatricesByProjectIdAndTestMatrixIdGet",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Cloud project that owns the test matrix."
+          },
+          {
+            "name": "testMatrixId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Unique test matrix id which was assigned by the service."
+          },
+          {
+            "name": "access_token",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "OAuth access token."
+          },
+          {
+            "name": "alt",
+            "in": "query",
+            "required": false,
+            "default": "json",
+            "type": "string",
+            "description": "Data format for response. (Acceptable values are: \"json\", \"media\", \"proto\")"
+          },
+          {
+            "name": "bearer_token",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "OAuth bearer token."
+          },
+          {
+            "name": "callback",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "JSONP"
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Selector specifying which fields to include in a partial response."
+          },
+          {
+            "name": "key",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token."
+          },
+          {
+            "name": "oauth_token",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "OAuth 2.0 token for the current user."
+          },
+          {
+            "name": "pp",
+            "in": "query",
+            "required": false,
+            "default": true,
+            "type": "boolean",
+            "description": "Pretty-print response."
+          },
+          {
+            "name": "prettyPrint",
+            "in": "query",
+            "required": false,
+            "default": true,
+            "type": "boolean",
+            "description": "Returns response with indentations and line breaks."
+          },
+          {
+            "name": "quotaUser",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters."
+          },
+          {
+            "name": "upload_protocol",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Upload protocol for media (e.g. \"raw\", \"multipart\")."
+          },
+          {
+            "name": "uploadType",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Legacy upload protocol for media (e.g. \"media\", \"multipart\")."
+          },
+          {
+            "name": "$.xgafv",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "V1 error format. (Acceptable values are: \"1\", \"2\")"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/TestMatrix"
+            },
+            "examples": {}
+          }
+        },
+        "security": [
+          {
+            "auth": [
+              "https://www.googleapis.com/auth/cloud-platform",
+              "https://www.googleapis.com/auth/cloud-platform.read-only"
+            ]
+          }
+        ],
+        "x-unitTests": [],
+        "x-operation-settings": {
+          "CollectParameters": false,
+          "AllowDynamicQueryParameters": false,
+          "AllowDynamicFormParameters": false,
+          "IsMultiContentStreaming": false
+        }
+      }
+    },
+    "/v1/projects/{projectId}/testMatrices/{testMatrixId}:cancel": {
+      "post": {
+        "description": "Cancels unfinished test executions in a test matrix.\nThis call returns immediately and cancellation proceeds asychronously.\nIf the matrix is already final, this operation will have no effect.\n\nMay return any of the following canonical error codes:\n\n- PERMISSION_DENIED - if the user is not authorized to read project\n- INVALID_ARGUMENT - if the request is malformed\n- NOT_FOUND - if the Test Matrix does not exist",
+        "summary": "CancelV1ProjectsTestMatricesCancelByProjectId",
+        "tags": [
+          "testMatrices"
+        ],
+        "operationId": "V1ProjectsTestMatricesCancelByProjectIdAndTestMatrixIdPost",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Cloud project that owns the test."
+          },
+          {
+            "name": "testMatrixId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Test matrix that will be canceled."
+          },
+          {
+            "name": "access_token",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "OAuth access token."
+          },
+          {
+            "name": "alt",
+            "in": "query",
+            "required": false,
+            "default": "json",
+            "type": "string",
+            "description": "Data format for response. (Acceptable values are: \"json\", \"media\", \"proto\")"
+          },
+          {
+            "name": "bearer_token",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "OAuth bearer token."
+          },
+          {
+            "name": "callback",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "JSONP"
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Selector specifying which fields to include in a partial response."
+          },
+          {
+            "name": "key",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token."
+          },
+          {
+            "name": "oauth_token",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "OAuth 2.0 token for the current user."
+          },
+          {
+            "name": "pp",
+            "in": "query",
+            "required": false,
+            "default": true,
+            "type": "boolean",
+            "description": "Pretty-print response."
+          },
+          {
+            "name": "prettyPrint",
+            "in": "query",
+            "required": false,
+            "default": true,
+            "type": "boolean",
+            "description": "Returns response with indentations and line breaks."
+          },
+          {
+            "name": "quotaUser",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters."
+          },
+          {
+            "name": "upload_protocol",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Upload protocol for media (e.g. \"raw\", \"multipart\")."
+          },
+          {
+            "name": "uploadType",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Legacy upload protocol for media (e.g. \"media\", \"multipart\")."
+          },
+          {
+            "name": "$.xgafv",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "V1 error format. (Acceptable values are: \"1\", \"2\")"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/CancelTestMatrixResponse"
+            },
+            "examples": {}
+          }
+        },
+        "security": [
+          {
+            "auth": [
+              "https://www.googleapis.com/auth/cloud-platform"
+            ]
+          }
+        ],
+        "x-unitTests": [],
+        "x-operation-settings": {
+          "CollectParameters": false,
+          "AllowDynamicQueryParameters": false,
+          "AllowDynamicFormParameters": false,
+          "IsMultiContentStreaming": false
+        }
+      }
+    }
+  },
+  "definitions": {
+    "TestEnvironmentCatalog": {
+      "title": "TestEnvironmentCatalog",
+      "description": "A description of a test environment.",
+      "type": "object",
+      "properties": {
+        "androidDeviceCatalog": {
+          "description": "Android devices suitable for running Android Instrumentation Tests.",
+          "type": "object"
+        },
+        "networkConfigurationCatalog": {
+          "description": "Supported network configurations",
+          "type": "object"
+        }
+      }
+    },
+    "AndroidDeviceCatalog": {
+      "title": "AndroidDeviceCatalog",
+      "description": "The currently supported Android devices.",
+      "type": "object",
+      "properties": {
+        "models": {
+          "description": "The set of supported Android device models.\n@OutputOnly",
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "versions": {
+          "description": "The set of supported Android OS versions.\n@OutputOnly",
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "runtimeConfiguration": {
+          "description": "The set of supported runtime configurations.\n@OutputOnly",
+          "type": "object"
+        }
+      }
+    },
+    "AndroidModel": {
+      "title": "AndroidModel",
+      "description": "A description of an Android device tests may be run on.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "The unique opaque id for this model.\nUse this for invoking the TestExecutionService.\n@OutputOnly",
+          "type": "string"
+        },
+        "name": {
+          "description": "The human-readable marketing name for this device model.\nExamples: \"Nexus 5\", \"Galaxy S5\"\n@OutputOnly",
+          "type": "string"
+        },
+        "manufacturer": {
+          "description": "The manufacturer of this device.\n@OutputOnly",
+          "type": "string"
+        },
+        "brand": {
+          "description": "The company that this device is branded with.\nExample: \"Google\", \"Samsung\"\n@OutputOnly",
+          "type": "string"
+        },
+        "codename": {
+          "description": "The name of the industrial design.\nThis corresponds to android.os.Build.DEVICE\n@OutputOnly",
+          "type": "string"
+        },
+        "form": {
+          "$ref": "#/definitions/Form"
+        },
+        "screenX": {
+          "description": "Screen size in the horizontal (X) dimension measured in pixels.\n@OutputOnly",
+          "type": "integer",
+          "format": "int32"
+        },
+        "screenY": {
+          "description": "Screen size in the vertical (Y) dimension measured in pixels.\n@OutputOnly",
+          "type": "integer",
+          "format": "int32"
+        },
+        "screenDensity": {
+          "description": "Screen density in DPI.\nThis corresponds to ro.sf.lcd_density\n@OutputOnly",
+          "type": "integer",
+          "format": "int32"
+        },
+        "supportedVersionIds": {
+          "description": "The set of Android versions this device supports.\n@OutputOnly",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "supportedAbis": {
+          "description": "The list of supported ABIs for this device.\nThis corresponds to either android.os.Build.SUPPORTED_ABIS (for API level\n21 and above) or android.os.Build.CPU_ABI/CPU_ABI2.\nThe most preferred ABI is the first element in the list.\n\nElements are optionally prefixed by \"version_id:\" (where version_id is\nthe id of an AndroidVersion), denoting an ABI that is supported only on\na particular version.\n@OutputOnly",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tags": {
+          "description": "Tags for this dimension.\nExamples: \"default\", \"preview\", \"deprecated\"",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Form": {
+      "title": "Form",
+      "example": "DEVICE_FORM_UNSPECIFIED",
+      "type": "string",
+      "enum": [
+        "DEVICE_FORM_UNSPECIFIED",
+        "VIRTUAL",
+        "PHYSICAL"
+      ]
+    },
+    "AndroidVersion": {
+      "title": "AndroidVersion",
+      "description": "A version of the Android OS",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "An opaque id for this Android version.\nUse this id to invoke the TestExecutionService.\n@OutputOnly",
+          "type": "string"
+        },
+        "versionString": {
+          "description": "A string representing this version of the Android OS.\nExamples: \"4.3\", \"4.4\"\n@OutputOnly",
+          "type": "string"
+        },
+        "apiLevel": {
+          "description": "The API level for this Android version.\nExamples: 18, 19\n@OutputOnly",
+          "type": "integer",
+          "format": "int32"
+        },
+        "codeName": {
+          "description": "The code name for this Android version.\nExamples: \"JellyBean\", \"KitKat\"\n@OutputOnly",
+          "type": "string"
+        },
+        "releaseDate": {
+          "description": "The date this Android version became available in the market.\n@OutputOnly",
+          "type": "object"
+        },
+        "distribution": {
+          "description": "Market share for this version.\n@OutputOnly",
+          "type": "object"
+        },
+        "tags": {
+          "description": "Tags for this dimension.\nExamples: \"default\", \"preview\", \"deprecated\"",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Date5": {
+      "title": "Date5",
+      "description": "Represents a whole calendar date, e.g. date of birth. The time of day and\ntime zone are either specified elsewhere or are not significant. The date\nis relative to the Proleptic Gregorian Calendar. The day may be 0 to\nrepresent a year and month where the day is not significant, e.g. credit card\nexpiration date. The year may be 0 to represent a month and day independent\nof year, e.g. anniversary date. Related types are google.type.TimeOfDay\nand `google.protobuf.Timestamp`.",
+      "type": "object",
+      "properties": {
+        "year": {
+          "description": "Year of date. Must be from 1 to 9999, or 0 if specifying a date without\na year.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "month": {
+          "description": "Month of year. Must be from 1 to 12.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "day": {
+          "description": "Day of month. Must be from 1 to 31 and valid for the year and month, or 0\nif specifying a year/month where the day is not significant.",
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "Distribution": {
+      "title": "Distribution",
+      "description": "Data about the relative number of devices running a\ngiven configuration of the Android platform.",
+      "type": "object",
+      "properties": {
+        "measurementTime": {
+          "description": "The time this distribution was measured.\n@OutputOnly",
+          "type": "string"
+        },
+        "marketShare": {
+          "description": "The estimated fraction (0-1) of the total market with this configuration.\n@OutputOnly",
+          "type": "number",
+          "format": "double"
+        }
+      }
+    },
+    "AndroidRuntimeConfiguration": {
+      "title": "AndroidRuntimeConfiguration",
+      "description": "Configuration that can be selected at the time a test is run.",
+      "type": "object",
+      "properties": {
+        "locales": {
+          "description": "The set of available locales.\n@OutputOnly",
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "orientations": {
+          "description": "The set of available orientations.\n@OutputOnly",
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "Locale": {
+      "title": "Locale",
+      "description": "A location/region designation for language.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "The id for this locale.\nExample: \"en_US\"\n@OutputOnly",
+          "type": "string"
+        },
+        "name": {
+          "description": "A human-friendly name for this language/locale.\nExample: \"English\"\n@OutputOnly",
+          "type": "string"
+        },
+        "region": {
+          "description": "A human-friendy string representing the region for this locale.\nExample: \"United States\"\nNot present for every locale.\n@OutputOnly",
+          "type": "string"
+        },
+        "tags": {
+          "description": "Tags for this dimension.\nExamples: \"default\"",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Orientation": {
+      "title": "Orientation",
+      "description": "Screen orientation of the device.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "The id for this orientation.\nExample: \"portrait\"\n@OutputOnly",
+          "type": "string"
+        },
+        "name": {
+          "description": "A human-friendly name for this orientation.\nExample: \"portrait\"\n@OutputOnly",
+          "type": "string"
+        },
+        "tags": {
+          "description": "Tags for this dimension.\nExamples: \"default\"",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "NetworkConfigurationCatalog": {
+      "title": "NetworkConfigurationCatalog",
+      "type": "object",
+      "properties": {
+        "configurations": {
+          "description": "",
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "NetworkConfiguration": {
+      "title": "NetworkConfiguration",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "The unique opaque id for this network traffic configuration\n@OutputOnly",
+          "type": "string"
+        },
+        "upRule": {
+          "description": "The emulation rule applying to the upload traffic",
+          "type": "object"
+        },
+        "downRule": {
+          "description": "The emulation rule applying to the download traffic",
+          "type": "object"
+        }
+      }
+    },
+    "TrafficRule": {
+      "title": "TrafficRule",
+      "description": "Network emulation parameters",
+      "type": "object",
+      "properties": {
+        "delay": {
+          "description": "Packet delay, must be >= 0",
+          "type": "string"
+        },
+        "packetLossRatio": {
+          "description": "Packet loss ratio (0.0 - 1.0)",
+          "type": "number",
+          "format": "double"
+        },
+        "packetDuplicationRatio": {
+          "description": "Packet duplication ratio (0.0 - 1.0)",
+          "type": "number",
+          "format": "double"
+        },
+        "bandwidth": {
+          "description": "Bandwidth in kbits/second",
+          "type": "number",
+          "format": "double"
+        },
+        "burst": {
+          "description": "Burst size in kbits",
+          "type": "number",
+          "format": "double"
+        }
+      }
+    },
+    "TestMatrix": {
+      "title": "TestMatrix",
+      "description": "A group of one or more TestExecutions, built by taking a\nproduct of values over a pre-defined set of axes.",
+      "type": "object",
+      "properties": {
+        "testMatrixId": {
+          "description": "Unique id set by the service.\n@OutputOnly",
+          "type": "string"
+        },
+        "projectId": {
+          "description": "The cloud project that owns the test matrix.\n@OutputOnly",
+          "type": "string"
+        },
+        "clientInfo": {
+          "description": "Information about the client which invoked the test.\nOptional",
+          "type": "object"
+        },
+        "testSpecification": {
+          "description": "How to run the test.\nRequired",
+          "type": "object"
+        },
+        "environmentMatrix": {
+          "description": "How the host machine(s) are configured.\nRequired",
+          "type": "object"
+        },
+        "testExecutions": {
+          "description": "The list of test executions that the service creates for this matrix.\n@OutputOnly",
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "resultStorage": {
+          "description": "Where the results for the matrix are written.\nRequired",
+          "type": "object"
+        },
+        "state": {
+          "$ref": "#/definitions/State"
+        },
+        "timestamp": {
+          "description": "The time this test matrix was initially created.\n@OutputOnly",
+          "type": "string"
+        },
+        "invalidMatrixDetails": {
+          "$ref": "#/definitions/InvalidMatrixDetails"
+        }
+      }
+    },
+    "State": {
+      "title": "State",
+      "example": "TEST_STATE_UNSPECIFIED",
+      "type": "string",
+      "enum": [
+        "TEST_STATE_UNSPECIFIED",
+        "VALIDATING",
+        "PENDING",
+        "RUNNING",
+        "FINISHED",
+        "ERROR",
+        "UNSUPPORTED_ENVIRONMENT",
+        "INCOMPATIBLE_ENVIRONMENT",
+        "INCOMPATIBLE_ARCHITECTURE",
+        "CANCELLED",
+        "INVALID"
+      ]
+    },
+    "InvalidMatrixDetails": {
+      "title": "InvalidMatrixDetails",
+      "example": "INVALID_MATRIX_DETAILS_UNSPECIFIED",
+      "type": "string",
+      "enum": [
+        "INVALID_MATRIX_DETAILS_UNSPECIFIED",
+        "DETAILS_UNAVAILABLE",
+        "MALFORMED_APK",
+        "MALFORMED_TEST_APK",
+        "NO_MANIFEST",
+        "NO_PACKAGE_NAME",
+        "TEST_SAME_AS_APP",
+        "NO_INSTRUMENTATION",
+        "NO_SIGNATURE",
+        "INSTRUMENTATION_ORCHESTRATOR_INCOMPATIBLE",
+        "NO_TEST_RUNNER_CLASS",
+        "NO_LAUNCHER_ACTIVITY",
+        "FORBIDDEN_PERMISSIONS",
+        "INVALID_ROBO_DIRECTIVES",
+        "TEST_LOOP_INTENT_FILTER_NOT_FOUND",
+        "SCENARIO_LABEL_NOT_DECLARED",
+        "SCENARIO_LABEL_MALFORMED",
+        "SCENARIO_NOT_DECLARED",
+        "DEVICE_ADMIN_RECEIVER",
+        "TEST_ONLY_APK"
+      ]
+    },
+    "ClientInfo": {
+      "title": "ClientInfo",
+      "description": "Information about the client which invoked the test.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Client name, such as gcloud.\nRequired",
+          "type": "string"
+        },
+        "clientInfoDetails": {
+          "description": "The list of detailed information about client.",
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "ClientInfoDetail": {
+      "title": "ClientInfoDetail",
+      "description": "Key-value pair of detailed information about the client which invoked the\ntest. For example {'Version', '1.0'}, {'Release Track', 'BETA'}",
+      "type": "object",
+      "properties": {
+        "key": {
+          "description": "The key of detailed client information.\nRequired",
+          "type": "string"
+        },
+        "value": {
+          "description": "The value of detailed client information.\nRequired",
+          "type": "string"
+        }
+      }
+    },
+    "TestSpecification": {
+      "title": "TestSpecification",
+      "description": "A description of how to run the test.",
+      "type": "object",
+      "properties": {
+        "testTimeout": {
+          "description": "Max time a test execution is allowed to run before it is\nautomatically cancelled.\nOptional, default is 5 min.",
+          "type": "string"
+        },
+        "testSetup": {
+          "description": "Test setup requirements e.g. files to install, bootstrap scripts\nOptional",
+          "type": "object"
+        },
+        "androidInstrumentationTest": {
+          "description": "An Android instrumentation test.",
+          "type": "object"
+        },
+        "androidRoboTest": {
+          "description": "An Android robo test.",
+          "type": "object"
+        },
+        "androidTestLoop": {
+          "description": "An Android Application with a Test Loop",
+          "type": "object"
+        },
+        "autoGoogleLogin": {
+          "description": "Enables automatic Google account login.\nIf set, the service will automatically generate a Google test account and\nadd it to the device, before executing the test. Note that test accounts\nmight be reused.\nMany applications show their full set of functionalities when an account is\npresent on the device. Logging into the device with these generated\naccounts allows testing more functionalities.\nDefault is false.\nOptional",
+          "type": "boolean"
+        },
+        "disableVideoRecording": {
+          "description": "Disables video recording; may reduce test latency.",
+          "type": "boolean"
+        },
+        "disablePerformanceMetrics": {
+          "description": "Disables performance metrics recording; may reduce test latency.",
+          "type": "boolean"
+        }
+      }
+    },
+    "TestSetup": {
+      "title": "TestSetup",
+      "description": "A description of how to set up the device prior to running the test",
+      "type": "object",
+      "properties": {
+        "filesToPush": {
+          "description": "List of files to push to the device before starting the test.\n\nOptional",
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "directoriesToPull": {
+          "description": "List of directories on the device to upload to GCS at the end of the test;\nthey must be absolute paths under /sdcard or /data/local/tmp.\nPath names are restricted to characters a-z A-Z 0-9 _ - . + and /\n\nNote: The paths /sdcard and /data will be made available and treated as\nimplicit path substitutions. E.g. if /sdcard on a particular device does\nnot map to external storage, the system will replace it with the external\nstorage path prefix for that device.\n\nOptional",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "account": {
+          "description": "The device will be logged in on this account for the duration of the test.\nOptional",
+          "type": "object"
+        },
+        "networkProfile": {
+          "description": "The network traffic profile used for running the test.\nOptional",
+          "type": "string"
+        },
+        "environmentVariables": {
+          "description": "Environment variables to set for the test (only applicable for\ninstrumentation tests).",
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "DeviceFile": {
+      "title": "DeviceFile",
+      "description": "A single device file description.",
+      "type": "object",
+      "properties": {
+        "obbFile": {
+          "description": "A reference to an opaque binary blob file",
+          "type": "object"
+        }
+      }
+    },
+    "ObbFile": {
+      "title": "ObbFile",
+      "description": "An opaque binary blob file to install on the device before the test starts",
+      "type": "object",
+      "properties": {
+        "obbFileName": {
+          "description": "OBB file name which must conform to the format as specified by\nAndroid\ne.g. [main|patch].0300110.com.example.android.obb\nwhich will be installed into\n  <shared-storage>/Android/obb/<package-name>/\non the device\nRequired",
+          "type": "string"
+        },
+        "obb": {
+          "description": "Opaque Binary Blob (OBB) file(s) to install on the device\nRequired",
+          "type": "object"
+        }
+      }
+    },
+    "FileReference": {
+      "title": "FileReference",
+      "description": "A reference to a file, used for user inputs.",
+      "type": "object",
+      "properties": {
+        "gcsPath": {
+          "description": "A path to a file in Google Cloud Storage.\nExample: gs://build-app-1414623860166/app-debug-unaligned.apk",
+          "type": "string"
+        }
+      }
+    },
+    "Account": {
+      "title": "Account",
+      "description": "Identifies an account and how to log into it",
+      "type": "object",
+      "properties": {
+        "googleAuto": {
+          "description": "An automatic google login account",
+          "type": "object"
+        }
+      }
+    },
+    "EnvironmentVariable": {
+      "title": "EnvironmentVariable",
+      "description": "A key-value pair passed as an environment variable to the test",
+      "type": "object",
+      "properties": {
+        "key": {
+          "description": "Key for the environment variable",
+          "type": "string"
+        },
+        "value": {
+          "description": "Value for the environment variable",
+          "type": "string"
+        }
+      }
+    },
+    "AndroidInstrumentationTest": {
+      "title": "AndroidInstrumentationTest",
+      "description": "A test of an Android application that can control an Android component\nindependently of its normal lifecycle.\nAndroid instrumentation tests run an application APK and test APK inside the\nsame process on a virtual or physical AndroidDevice.  They also specify\na test runner class, such as com.google.GoogleTestRunner, which can vary\non the specific instrumentation framework chosen.\n\nSee <http://developer.android.com/tools/testing/testing_android.html> for\nmore information on types of Android tests.",
+      "type": "object",
+      "properties": {
+        "appApk": {
+          "$ref": "#/definitions/FileReference"
+        },
+        "testApk": {
+          "$ref": "#/definitions/FileReference"
+        },
+        "appPackageId": {
+          "description": "The java package for the application under test.\nOptional, default is determined by examining the application's manifest.",
+          "type": "string"
+        },
+        "testPackageId": {
+          "description": "The java package for the test to be executed.\nOptional, default is determined by examining the application's manifest.",
+          "type": "string"
+        },
+        "testRunnerClass": {
+          "description": "The InstrumentationTestRunner class.\nOptional, default is determined by examining the application's manifest.",
+          "type": "string"
+        },
+        "testTargets": {
+          "description": "Each target must be fully qualified with the package name or class name,\nin one of these formats:\n - \"package package_name\"\n - \"class package_name.class_name\"\n - \"class package_name.class_name#method_name\"\n\nOptional, if empty, all targets in the module will be run.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "orchestratorOption": {
+          "$ref": "#/definitions/OrchestratorOption"
+        }
+      }
+    },
+    "OrchestratorOption": {
+      "title": "OrchestratorOption",
+      "example": "ORCHESTRATOR_OPTION_UNSPECIFIED",
+      "type": "string",
+      "enum": [
+        "ORCHESTRATOR_OPTION_UNSPECIFIED",
+        "USE_ORCHESTRATOR",
+        "DO_NOT_USE_ORCHESTRATOR"
+      ]
+    },
+    "AndroidRoboTest": {
+      "title": "AndroidRoboTest",
+      "description": "A test of an android application that explores the application on a virtual\nor physical Android Device, finding culprits and crashes as it goes.",
+      "type": "object",
+      "properties": {
+        "appApk": {
+          "$ref": "#/definitions/FileReference"
+        },
+        "appPackageId": {
+          "description": "The java package for the application under test.\nOptional, default is determined by examining the application's manifest.",
+          "type": "string"
+        },
+        "appInitialActivity": {
+          "description": "The initial activity that should be used to start the app.\nOptional",
+          "type": "string"
+        },
+        "maxDepth": {
+          "description": "The max depth of the traversal stack Robo can explore. Needs to be at least\n2 to make Robo explore the app beyond the first activity.\nDefault is 50.\nOptional",
+          "type": "integer",
+          "format": "int32"
+        },
+        "maxSteps": {
+          "description": "The max number of steps Robo can execute.\nDefault is no limit.\nOptional",
+          "type": "integer",
+          "format": "int32"
+        },
+        "roboDirectives": {
+          "description": "A set of directives Robo should apply during the crawl.\nThis allows users to customize the crawl. For example, the username and\npassword for a test account can be provided.\nOptional",
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "RoboDirective": {
+      "title": "RoboDirective",
+      "description": "Directs Robo to interact with a specific UI element if it is encountered\nduring the crawl. Currently, Robo can perform text entry or element click.",
+      "type": "object",
+      "properties": {
+        "resourceName": {
+          "description": "The android resource name of the target UI element\nFor example,\n   in Java: R.string.foo\n   in xml: @string/foo\nOnly the “foo” part is needed.\nReference doc:\nhttps://developer.android.com/guide/topics/resources/accessing-resources.html\nRequired",
+          "type": "string"
+        },
+        "inputText": {
+          "description": "The text that Robo is directed to set. If left empty, the directive will be\ntreated as a CLICK on the element matching the resource_name.\nOptional",
+          "type": "string"
+        },
+        "actionType": {
+          "$ref": "#/definitions/ActionType"
+        }
+      }
+    },
+    "ActionType": {
+      "title": "ActionType",
+      "example": "ACTION_TYPE_UNSPECIFIED",
+      "type": "string",
+      "enum": [
+        "ACTION_TYPE_UNSPECIFIED",
+        "SINGLE_CLICK",
+        "ENTER_TEXT"
+      ]
+    },
+    "AndroidTestLoop": {
+      "title": "AndroidTestLoop",
+      "description": "A test of an Android Application with a Test Loop.\nThe intent <intent-name> will be implicitly added, since Games is the only\nuser of this api, for the time being.",
+      "type": "object",
+      "properties": {
+        "appApk": {
+          "$ref": "#/definitions/FileReference"
+        },
+        "appPackageId": {
+          "description": "The java package for the application under test.\nOptional, default is determined by examining the application's manifest.",
+          "type": "string"
+        },
+        "scenarios": {
+          "description": "The list of scenarios that should be run during the test.\nOptional, default is all test loops, derived from the application's\nmanifest.",
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "scenarioLabels": {
+          "description": "The list of scenario labels that should be run during the test.\nThe scenario labels should map to labels defined in the application's\nmanifest. For example, player_experience and\ncom.google.test.loops.player_experience add all of the loops labeled in the\nmanifest with the com.google.test.loops.player_experience name to the\nexecution.\nOptional. Scenarios can also be specified in the scenarios field.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "EnvironmentMatrix": {
+      "title": "EnvironmentMatrix",
+      "description": "The matrix of environments in which the test is to be executed.",
+      "type": "object",
+      "properties": {
+        "androidMatrix": {
+          "description": "A matrix of Android devices.",
+          "type": "object"
+        },
+        "androidDeviceList": {
+          "description": "A list of Android devices; the test will be run only on the specified\ndevices.",
+          "type": "object"
+        }
+      }
+    },
+    "AndroidMatrix": {
+      "title": "AndroidMatrix",
+      "description": "A set of Android device configuration permutations is defined by the\nthe cross-product of the given axes.  Internally, the given AndroidMatrix\nwill be expanded into a set of AndroidDevices.\n\nOnly supported permutations will be instantiated.  Invalid permutations\n(e.g., incompatible models/versions) are ignored.",
+      "type": "object",
+      "properties": {
+        "androidModelIds": {
+          "description": "The ids of the set of Android device to be used.\nUse the EnvironmentDiscoveryService to get supported options.\nRequired",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "androidVersionIds": {
+          "description": "The ids of the set of Android OS version to be used.\nUse the EnvironmentDiscoveryService to get supported options.\nRequired",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "locales": {
+          "description": "The set of locales the test device will enable for testing.\nUse the EnvironmentDiscoveryService to get supported options.\nRequired",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "orientations": {
+          "description": "The set of orientations to test with.\nUse the EnvironmentDiscoveryService to get supported options.\nRequired",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "AndroidDeviceList": {
+      "title": "AndroidDeviceList",
+      "description": "A list of Android device configurations in which the test is to be executed.",
+      "type": "object",
+      "properties": {
+        "androidDevices": {
+          "description": "A list of Android devices\nRequired",
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "AndroidDevice": {
+      "title": "AndroidDevice",
+      "description": "A single Android device.",
+      "type": "object",
+      "properties": {
+        "androidModelId": {
+          "description": "The id of the Android device to be used.\nUse the EnvironmentDiscoveryService to get supported options.\nRequired",
+          "type": "string"
+        },
+        "androidVersionId": {
+          "description": "The id of the Android OS version to be used.\nUse the EnvironmentDiscoveryService to get supported options.\nRequired",
+          "type": "string"
+        },
+        "locale": {
+          "description": "The locale the test device used for testing.\nUse the EnvironmentDiscoveryService to get supported options.\nRequired",
+          "type": "string"
+        },
+        "orientation": {
+          "description": "How the device is oriented during the test.\nUse the EnvironmentDiscoveryService to get supported options.\nRequired",
+          "type": "string"
+        }
+      }
+    },
+    "TestExecution": {
+      "title": "TestExecution",
+      "description": "Specifies a single test to be executed in a single environment.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Unique id set by the backend.\n@OutputOnly",
+          "type": "string"
+        },
+        "matrixId": {
+          "description": "Id of the containing TestMatrix.\n@OutputOnly",
+          "type": "string"
+        },
+        "projectId": {
+          "description": "The cloud project that owns the test execution.\n@OutputOnly",
+          "type": "string"
+        },
+        "testSpecification": {
+          "$ref": "#/definitions/TestSpecification"
+        },
+        "environment": {
+          "description": "How the host machine(s) are configured.\n@OutputOnly",
+          "type": "object"
+        },
+        "state": {
+          "$ref": "#/definitions/State"
+        },
+        "toolResultsStep": {
+          "description": "Where the results for this execution are written.\n@OutputOnly",
+          "type": "object"
+        },
+        "timestamp": {
+          "description": "The time this test execution was initially created.\n@OutputOnly",
+          "type": "string"
+        },
+        "testDetails": {
+          "description": "Additional details about the running test.\n@OutputOnly",
+          "type": "object"
+        }
+      }
+    },
+    "Environment": {
+      "title": "Environment",
+      "description": "The environment in which the test is run.",
+      "type": "object",
+      "properties": {
+        "androidDevice": {
+          "$ref": "#/definitions/AndroidDevice"
+        }
+      }
+    },
+    "ToolResultsStep": {
+      "title": "ToolResultsStep",
+      "description": "Represents a tool results step resource.\n\nThis has the results of a TestExecution.",
+      "type": "object",
+      "properties": {
+        "projectId": {
+          "description": "The cloud project that owns the tool results step.\n@OutputOnly",
+          "type": "string"
+        },
+        "historyId": {
+          "description": "A tool results history ID.\n@OutputOnly",
+          "type": "string"
+        },
+        "executionId": {
+          "description": "A tool results execution ID.\n@OutputOnly",
+          "type": "string"
+        },
+        "stepId": {
+          "description": "A tool results step ID.\n@OutputOnly",
+          "type": "string"
+        }
+      }
+    },
+    "TestDetails": {
+      "title": "TestDetails",
+      "description": "Additional details about the progress of the running test.",
+      "type": "object",
+      "properties": {
+        "progressMessages": {
+          "description": "Human-readable, detailed descriptions of the test's progress.\nFor example: \"Provisioning a device\", \"Starting Test\".\n\nDuring the course of execution new data may be appended\nto the end of progress_messages.\n@OutputOnly",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "errorMessage": {
+          "description": "If the TestState is ERROR, then this string will contain human-readable\ndetails about the error.\n@OutputOnly",
+          "type": "string"
+        }
+      }
+    },
+    "ResultStorage": {
+      "title": "ResultStorage",
+      "description": "Locations where the results of running the test are stored.",
+      "type": "object",
+      "properties": {
+        "googleCloudStorage": {
+          "description": "Required.",
+          "type": "object"
+        },
+        "toolResultsHistory": {
+          "description": "The tool results history that contains the tool results execution that\nresults are written to.\n\nOptional, if not provided the service will choose an appropriate value.",
+          "type": "object"
+        },
+        "toolResultsExecution": {
+          "description": "The tool results execution that results are written to.\n@OutputOnly",
+          "type": "object"
+        }
+      }
+    },
+    "GoogleCloudStorage": {
+      "title": "GoogleCloudStorage",
+      "description": "A storage location within Google cloud storage (GCS).",
+      "type": "object",
+      "properties": {
+        "gcsPath": {
+          "description": "The path to a directory in GCS that will\neventually contain the results for this test.\nThe requesting user must have write access on the bucket in the supplied\npath.\nRequired",
+          "type": "string"
+        }
+      }
+    },
+    "ToolResultsHistory": {
+      "title": "ToolResultsHistory",
+      "description": "Represents a tool results history resource.",
+      "type": "object",
+      "properties": {
+        "projectId": {
+          "description": "The cloud project that owns the tool results history.\nRequired",
+          "type": "string"
+        },
+        "historyId": {
+          "description": "A tool results history ID.\nRequired",
+          "type": "string"
+        }
+      }
+    },
+    "ToolResultsExecution": {
+      "title": "ToolResultsExecution",
+      "description": "Represents a tool results execution resource.\n\nThis has the results of a TestMatrix.",
+      "type": "object",
+      "properties": {
+        "projectId": {
+          "description": "The cloud project that owns the tool results execution.\n@OutputOnly",
+          "type": "string"
+        },
+        "historyId": {
+          "description": "A tool results history ID.\n@OutputOnly",
+          "type": "string"
+        },
+        "executionId": {
+          "description": "A tool results execution ID.\n@OutputOnly",
+          "type": "string"
+        }
+      }
+    },
+    "CancelTestMatrixResponse": {
+      "title": "CancelTestMatrixResponse",
+      "description": "Response containing the current state of the specified test matrix.",
+      "type": "object",
+      "properties": {
+        "testState": {
+          "$ref": "#/definitions/TestState"
+        }
+      }
+    },
+    "TestState": {
+      "title": "TestState",
+      "example": "TEST_STATE_UNSPECIFIED",
+      "type": "string",
+      "enum": [
+        "TEST_STATE_UNSPECIFIED",
+        "VALIDATING",
+        "PENDING",
+        "RUNNING",
+        "FINISHED",
+        "ERROR",
+        "UNSUPPORTED_ENVIRONMENT",
+        "INCOMPATIBLE_ENVIRONMENT",
+        "INCOMPATIBLE_ARCHITECTURE",
+        "CANCELLED",
+        "INVALID"
+      ]
+    }
+  }
+}

--- a/cloud_testing/kotlin_poc/.gitignore
+++ b/cloud_testing/kotlin_poc/.gitignore
@@ -1,0 +1,1 @@
+results

--- a/cloud_testing/kotlin_poc/src/main/kotlin/ftl/GcTestMatrix.kt
+++ b/cloud_testing/kotlin_poc/src/main/kotlin/ftl/GcTestMatrix.kt
@@ -65,15 +65,24 @@ object GcTestMatrix {
                 // :(
                 e2.printStackTrace()
             }
-
         }
-
     }
 
     fun refresh(testMatrixId: String): TestMatrix {
         try {
             return GcTesting.get()!!.projects().testMatrices().get(projectId, testMatrixId).execute()
         } catch (e: Exception) {
+            // Getting the test matrix may throw an internal server error.
+            //  {
+            //      "code" : 500,
+            //      "errors" : [ {
+            //      "domain" : "global",
+            //      "message" : "Internal error encountered.",
+            //      "reason" : "backendError"
+            //  } ],
+            //      "message" : "Internal error encountered.",
+            //      "status" : "INTERNAL"
+            //  }
             fatalError(e)
         }
 

--- a/cloud_testing/kotlin_poc/src/main/kotlin/ftl/GlobalConfig.kt
+++ b/cloud_testing/kotlin_poc/src/main/kotlin/ftl/GlobalConfig.kt
@@ -11,6 +11,7 @@ object GlobalConfig {
 
     var bucketGcsPath = "tmp_bucket_2"
     var downloadXml = true
+    const val results = "results"
 
     // gcloud config get-value project
     //

--- a/cloud_testing/kotlin_poc/src/main/kotlin/ftl/Main.kt
+++ b/cloud_testing/kotlin_poc/src/main/kotlin/ftl/Main.kt
@@ -43,7 +43,7 @@ object Main {
         println("Test runner started.")
         val stopWatch = ftl.StopWatch().start()
 
-        val testMatrixIds = scheduleApks(appApk, testErrorApk, shardCount = 1, runConfig = runConfig)
+        val testMatrixIds = scheduleApks(appApk, testErrorApk, shardCount = 2, runConfig = runConfig)
 
         val allTestsSuccessful = pollTests(testMatrixIds)
 

--- a/cloud_testing/kotlin_poc/src/main/kotlin/ftl/Main.kt
+++ b/cloud_testing/kotlin_poc/src/main/kotlin/ftl/Main.kt
@@ -7,6 +7,7 @@ import ftl.GlobalConfig.testApk
 import ftl.GlobalConfig.testErrorApk
 import ftl.TestRunner.pollTests
 import ftl.TestRunner.scheduleApks
+import task.MergeResults
 import java.util.stream.Collectors
 
 object Main {
@@ -43,11 +44,13 @@ object Main {
         println("Test runner started.")
         val stopWatch = ftl.StopWatch().start()
 
-        val testMatrixIds = scheduleApks(appApk, testErrorApk, shardCount = 2, runConfig = runConfig)
+        val testMatrixIds = scheduleApks(appApk, testErrorApk, shardCount = 10, runConfig = runConfig)
 
         val allTestsSuccessful = pollTests(testMatrixIds)
 
         println("Finished in " + stopWatch.end())
+
+        MergeResults.execute()
 
         val exitCode = if (allTestsSuccessful) 0 else -1
         System.exit(exitCode)

--- a/cloud_testing/kotlin_poc/src/main/kotlin/ftl/MatrixCallable.kt
+++ b/cloud_testing/kotlin_poc/src/main/kotlin/ftl/MatrixCallable.kt
@@ -40,7 +40,7 @@ internal class MatrixCallable(private val testMatrixIds: MutableList<String>,
 
         var testMatrixId: String? = null
         var infrastructureFailure = false
-        for (i in 0..tryCount - 1) {
+        for (i in 0 until tryCount) {
             testMatrixId = executeTestMatrix()
 
             while (TestMatrixState.validatingOrPending(testMatrixId)) {

--- a/cloud_testing/kotlin_poc/src/main/kotlin/ftl/RunConfig.kt
+++ b/cloud_testing/kotlin_poc/src/main/kotlin/ftl/RunConfig.kt
@@ -3,6 +3,8 @@ package ftl
 data class RunConfig(
         val useOrchestrator: String = "USE_ORCHESTRATOR", // must be USE_ORCHESTRATOR or null
         val disablePerformanceMetrics: Boolean = true,
-        val disableVideoRecording: Boolean = true,
+        // Disabling video recording causes infrastructure failures because the AVD idles and disconnects.
+        // Until this is resolved, video recording must be enabled.
+        val disableVideoRecording: Boolean = false,
         val testTimeoutMinutes: Long = 5
 )

--- a/cloud_testing/kotlin_poc/src/main/kotlin/ftl/TestRunner.kt
+++ b/cloud_testing/kotlin_poc/src/main/kotlin/ftl/TestRunner.kt
@@ -19,7 +19,7 @@ object TestRunner {
     private const val FINISHED = "FINISHED"
     private const val SUCCESS = "success"
     private val storage = StorageOptions.newBuilder().build().service
-    private val testResultRgx = Regex(".*test_result_\\d+.xml$")
+    val testResultRgx = Regex(".*test_result_\\d+.xml$")
 
     // gcsFolder = "2018-01-17_19:38:56.695000_fCMj"
     private fun downloadXml(gcsFolder: String) {
@@ -37,7 +37,7 @@ object TestRunner {
             if (name.matches(testResultRgx)) {
                 xmlCount += 1
                 println("Downloading: $name")
-                val downloadFile = Paths.get(gcsFolder, "test_result_$xmlCount.xml")
+                val downloadFile = Paths.get(GlobalConfig.results, gcsFolder, "test_result_$xmlCount.xml")
                 downloadFile.parent.toFile().mkdirs()
                 it.downloadTo(downloadFile)
             }
@@ -193,6 +193,8 @@ object TestRunner {
     fun scheduleApks(appApk: Path, testApk: Path, shardCount: Int, runConfig: RunConfig): ArrayList<String> {
         val appApkGcsPath = uploadApk(appApk)
         val testApkGcsPath = uploadApk(testApk)
+
+        Paths.get(GlobalConfig.results).toFile().deleteRecursively()
 
         // *MUST* use synchronized list to play nice with ExecutorService
         val testMatrixIds = Collections.synchronizedList<String>(ArrayList(shardCount))

--- a/cloud_testing/kotlin_poc/src/main/kotlin/ftl/ToolResultsValue.kt
+++ b/cloud_testing/kotlin_poc/src/main/kotlin/ftl/ToolResultsValue.kt
@@ -5,7 +5,7 @@ import com.google.api.services.toolresults.model.StepDimensionValueEntry
 import ftl.Billing.billableMinutes
 import ftl.Constants.projectId
 
-internal class ToolResultsValue(step: Step, var toolResultsStep: ToolResultsStepGcsPath) {
+internal class ToolResultsValue(step: Step, toolResultsStep: ToolResultsStepGcsPath) {
     var webLink: String = ""
     var billableMinutes: Long = 0
     var testDurationSeconds: Long = 0
@@ -14,7 +14,7 @@ internal class ToolResultsValue(step: Step, var toolResultsStep: ToolResultsStep
     var targets: String
     var dimensions: List<StepDimensionValueEntry>
     var outcome: String
-    val step = toolResultsStep.toolResults
+    private val step = toolResultsStep.toolResults
     val gcsPath = toolResultsStep.gcsPath
 
     init {

--- a/cloud_testing/kotlin_poc/src/main/kotlin/ftl/ToolResultsValue.kt
+++ b/cloud_testing/kotlin_poc/src/main/kotlin/ftl/ToolResultsValue.kt
@@ -39,27 +39,8 @@ internal class ToolResultsValue(step: Step, toolResultsStep: ToolResultsStepGcsP
     }
 
     override fun toString(): String {
-        val dimensionSb = StringBuilder()
-
-        for (dimension in dimensions) {
-            dimensionSb
-                    .append("  ")
-                    .append(dimension.key)
-                    .append(": ")
-                    .append(dimension.value)
-                    .append("\n")
-        }
-
-        val dimensionString = dimensionSb.toString()
-
-        return """Billable minutes: ${billableMinutes}m
-Test duration: ${testDurationSeconds}s
-Run duration: ${runDurationSeconds}s
-Name: ${name}
-Targets: ${targets}
-Dimensions:
-$dimensionString
-Outcome: ${outcome}
+        return """Billable / test / run: ${billableMinutes}m / ${testDurationSeconds}s / ${runDurationSeconds}s
+Outcome: $outcome
 $webLink"""
     }
 }

--- a/cloud_testing/kotlin_poc/src/main/kotlin/task/MergeResults.kt
+++ b/cloud_testing/kotlin_poc/src/main/kotlin/task/MergeResults.kt
@@ -21,8 +21,6 @@ object MergeResults {
         }
 
         xmlFiles.forEach { file ->
-            println(file.name)
-
             val xml = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(file)
             xml.normalizeDocument()
             xml.documentElement.normalize()

--- a/cloud_testing/kotlin_poc/src/main/kotlin/task/MergeResults.kt
+++ b/cloud_testing/kotlin_poc/src/main/kotlin/task/MergeResults.kt
@@ -1,0 +1,53 @@
+package task
+
+import com.sun.org.apache.xerces.internal.dom.DeferredElementImpl
+import ftl.GlobalConfig
+import ftl.TestRunner.testResultRgx
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Paths
+import javax.xml.parsers.DocumentBuilderFactory
+
+object MergeResults {
+    @JvmStatic
+    fun main(args: Array<String>) {
+
+        val xmlFiles = mutableListOf<File>()
+        val results = mutableMapOf<String, Int>()
+
+        File(GlobalConfig.results).walk().forEach {
+            if (it.name.matches(testResultRgx)) {
+                xmlFiles.add(it)
+            }
+        }
+
+        xmlFiles.forEach { file ->
+            println(file.name)
+
+            val xml = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(file)
+            xml.normalizeDocument()
+            xml.documentElement.normalize()
+
+            val nodes = xml.getElementsByTagName("failure")
+
+            repeat(nodes.length) { index ->
+                val node: DeferredElementImpl = nodes.item(index) as DeferredElementImpl
+
+                val parent = node.parentNode.attributes
+                val className = parent.getNamedItem("classname").nodeValue
+                val testName = parent.getNamedItem("name").nodeValue
+                val key = "$className#$testName"
+                results[key] = results.getOrDefault(key, 0) + 1
+            }
+        }
+
+        val csv = Paths.get(GlobalConfig.results, "summary.csv")
+        val csvData = StringBuilder()
+
+        results.forEach {
+            csvData.append(it.key, ',', it.value, "\n")
+        }
+
+        Files.write(csv, csvData.toString().toByteArray())
+    }
+}

--- a/cloud_testing/kotlin_poc/src/main/kotlin/task/MergeResults.kt
+++ b/cloud_testing/kotlin_poc/src/main/kotlin/task/MergeResults.kt
@@ -9,9 +9,8 @@ import java.nio.file.Paths
 import javax.xml.parsers.DocumentBuilderFactory
 
 object MergeResults {
-    @JvmStatic
-    fun main(args: Array<String>) {
 
+    fun execute() {
         val xmlFiles = mutableListOf<File>()
         val results = mutableMapOf<String, Int>()
 
@@ -49,5 +48,10 @@ object MergeResults {
         }
 
         Files.write(csv, csvData.toString().toByteArray())
+    }
+
+    @JvmStatic
+    fun main(args: Array<String>) {
+       execute()
     }
 }

--- a/cloud_testing/readme.md
+++ b/cloud_testing/readme.md
@@ -54,3 +54,11 @@ Generated automatically from `gcloud-cli/googlecloudsdk/third_party/apis/testing
 ## Build
 
 - `gradle build`
+
+## Testing
+
+API Discovery JSON may be converted to Swagger V2 using [apimatic.io/transformer](https://apimatic.io/transformer). [Stoplight prism](http://stoplight.io/platform/prism/) can then be used to spin up a local mock server.
+
+> prism run --mock --list --spec testing_v1_swagger_2.json
+
+For example, visiting `http://localhost:4010/v1/projects/123/testMatrices/456` will return a random valid result based on the Swagger schema.


### PR DESCRIPTION
I'm working on updating `cloud_testing` to run my suite of ~150 Espresso tests. I created a mock server by converting the API JSON into Swagger. This will allow testing different concurrency techniques (like coroutines) without having to use the real server.

Swagger mock server screenshot:

![image](https://user-images.githubusercontent.com/1173057/35135661-9e4b3b52-fcac-11e7-8c9a-f42120c6c60d.png)

I found a bug in FTL as part of this work (disabling video recording = 💥 ).