### PR TITLE
Add detailed polling based on gcloud-cli

### DIFF
--- a/cloud_testing/kotlin_poc/src/main/kotlin/ftl/util/MatrixState.kt
+++ b/cloud_testing/kotlin_poc/src/main/kotlin/ftl/util/MatrixState.kt
@@ -2,29 +2,24 @@ package ftl.util
 
 object MatrixState {
     // https://github.com/bootstraponline/studio-google-cloud-testing/blob/203ed2890c27a8078cd1b8f7ae12cf77527f426b/firebase-testing/src/com/google/gct/testing/CloudResultsLoader.java#L237
+    // see testing_v1.json TestMatrix state enum
 
-    // fatalError("Incompatible device/OS combination");
-    var UNSUPPORTED_ENVIRONMENT = "UNSUPPORTED_ENVIRONMENT"
-    var VALIDATING = "VALIDATING"
-
-    // fatalError("Application does not support the specified OS version");
-    var INCOMPATIBLE_ENVIRONMENT = "INCOMPATIBLE_ENVIRONMENT"
-
-    // fatalError("The provided APK is invalid");
-    var INVALID = "INVALID"
-
-    // fatalError("Application does not support the specified device architecture");
-    var INCOMPATIBLE_ARCHITECTURE = "INCOMPATIBLE_ARCHITECTURE"
-    var PENDING = "PENDING"
-
-    // INFRASTRUCTURE_FAILURE.  testExecution.getTestDetails().getErrorMessage());
-    var ERROR = "ERROR"
-    // testExecution.getTestDetails().getProgressMessages();
-    var RUNNING = "RUNNING"
-    var FINISHED = "FINISHED"
+    private const val TEST_STATE_UNSPECIFIED = "TEST_STATE_UNSPECIFIED"
+    private const val VALIDATING = "VALIDATING"
+    private const val PENDING = "PENDING"
+    private const val RUNNING = "RUNNING"
+    const val FINISHED = "FINISHED"
+    private const val ERROR = "ERROR"
+    private const val UNSUPPORTED_ENVIRONMENT = "UNSUPPORTED_ENVIRONMENT" // Incompatible device/OS combination
+    private const val INCOMPATIBLE_ENVIRONMENT = "INCOMPATIBLE_ENVIRONMENT" // Application does not support the specified OS version
+    private const val INCOMPATIBLE_ARCHITECTURE = "INCOMPATIBLE_ARCHITECTURE" // Application does not support the specified device architecture
+    private const val CANCELLED = "CANCELLED"
+    private const val INVALID = "INVALID" // The provided APK is invalid
 
     fun inProgress(state: String): Boolean {
         return when (state) {
+            CANCELLED -> false
+            TEST_STATE_UNSPECIFIED -> false
             UNSUPPORTED_ENVIRONMENT -> false
             VALIDATING -> true
             INCOMPATIBLE_ENVIRONMENT -> false
@@ -38,5 +33,9 @@ object MatrixState {
                 throw RuntimeException("Unknown state: $state")
             }
         }
+    }
+
+    fun completed(state: String): Boolean {
+        return !inProgress(state)
     }
 }

--- a/cloud_testing/kotlin_poc/src/main/kotlin/ftl/util/StopWatch.kt
+++ b/cloud_testing/kotlin_poc/src/main/kotlin/ftl/util/StopWatch.kt
@@ -21,7 +21,7 @@ class StopWatch {
         return TimeUnit.MILLISECONDS.toSeconds(duration)
     }
 
-    fun check(): String {
+    fun check(indent: Boolean = false): String {
         if (startTime == 0L) {
             throw RuntimeException("startTime is zero. start not called")
         }
@@ -31,7 +31,13 @@ class StopWatch {
         val minutes = minutes(duration)
         val seconds = seconds(duration) % 60
 
-        return String.format("%dm %ds", minutes, seconds)
+        // align seconds
+        // 3m  0s
+        // 2m 23s
+        var space = " "
+        if (indent && seconds < 10) space = "  "
+
+        return String.format("%dm$space%ds", minutes, seconds)
     }
 
     fun reset(): StopWatch {


### PR DESCRIPTION
Report test execution status instead of matrix status.

**before**

```
pollMatrices
  matrix-b5a6sge0q1cw VALIDATING 0m 0s
  matrix-b5a6sge0q1cw PENDING 0m 15s
  matrix-b5a6sge0q1cw PENDING 0m 30s
  matrix-b5a6sge0q1cw PENDING 0m 46s
  matrix-b5a6sge0q1cw PENDING 1m 1s
  matrix-b5a6sge0q1cw PENDING 1m 16s
  matrix-b5a6sge0q1cw PENDING 1m 31s
  matrix-b5a6sge0q1cw PENDING 1m 47s
  matrix-b5a6sge0q1cw PENDING 2m 2s
  matrix-b5a6sge0q1cw PENDING 2m 17s
  matrix-b5a6sge0q1cw PENDING 2m 33s
  matrix-b5a6sge0q1cw PENDING 2m 48s
  matrix-b5a6sge0q1cw FINISHED 3m 3s
```

**after**

```
pollMatrices
  0m  0s matrix-2k3bs3s26p24n VALIDATING
  0m  6s matrix-2k3bs3s26p24n PENDING
  0m 37s matrix-2k3bs3s26p24n Starting attempt 1
  0m 37s matrix-2k3bs3s26p24n RUNNING
  1m 59s matrix-2k3bs3s26p24n Running instrumentation test. Package: com.example.app.test testrunner: android.support.test.runner.AndroidJUnitRunner useOrchestrator: true options: [key: CLASS
val: "com.example.app.ExampleUiTest#testPasses"
]
  2m  5s matrix-2k3bs3s26p24n Instrumentation test has finished
  2m  5s matrix-2k3bs3s26p24n Generating video
  2m 11s matrix-2k3bs3s26p24n Retrieving test artifacts
  2m 11s matrix-2k3bs3s26p24n Retrieving any crash results
  2m 43s matrix-2k3bs3s26p24n Processing Logcat.
  2m 49s matrix-2k3bs3s26p24n Done. Test time=10 (secs)
```