### PR TITLE
Report that tests failed if a gcloud command fails.

### DIFF
--- a/Flank/src/main/java/com/walmart/otto/tools/GcloudTool.java
+++ b/Flank/src/main/java/com/walmart/otto/tools/GcloudTool.java
@@ -115,8 +115,8 @@ public class GcloudTool extends Tool {
         latestExecutionTime = Integer.parseInt(timeLine[1].replaceAll("\\D+", ""));
         TimeReporter.addExecutionTime(Integer.parseInt(timeLine[1].replaceAll("\\D+", "")));
       } else if (line.contains("ERROR")) {
-        //TODO retry when error is returned from FTL
-        //throw new RuntimeException(line);
+        System.out.println("Gcloud command failed to run. Reporting that tests failed.\n" + line);
+        testFailed = true;
       }
     }
 


### PR DESCRIPTION
If a gcloud command fails, that means that the build failed. We should
return a -1 error code.

Without this its impossible to know if a single shard failed while all
the other ones succeeded.

Fixes #22 