### PR TITLE
Add ability to disable google login.

### DIFF
--- a/Flank/src/main/java/com/walmart/otto/configurator/ConfigReader.java
+++ b/Flank/src/main/java/com/walmart/otto/configurator/ConfigReader.java
@@ -136,6 +136,10 @@ public class ConfigReader {
         configurator.setGenerateSplitVideo(Boolean.parseBoolean(value));
         break;
 
+      case "disable-google-login":
+        configurator.setDisableAutoGoogleLogin(Boolean.parseBoolean(value));
+        break;
+
       default:
         break;
     }

--- a/Flank/src/main/java/com/walmart/otto/configurator/Configurator.java
+++ b/Flank/src/main/java/com/walmart/otto/configurator/Configurator.java
@@ -24,6 +24,7 @@ public class Configurator {
   private boolean fetchXMLFiles = true;
   private boolean debug = false;
   private boolean fetchBucket = false;
+  private boolean disableAutoGoogleLogin = false;
   private int numShards = -1;
   private int shardIndex = -1;
   private int shardTimeout = 5;
@@ -190,6 +191,14 @@ public class Configurator {
 
   public void setUseGCloudBeta(boolean useGCloudBeta) {
     this.useGCloudBeta = useGCloudBeta;
+  }
+
+  public boolean disableAutoGoogleLogin() {
+    return disableAutoGoogleLogin;
+  }
+
+  public void setDisableAutoGoogleLogin(boolean disableAutoGoogleLogin) {
+    this.disableAutoGoogleLogin = disableAutoGoogleLogin;
   }
 
   private void setupDevices() {

--- a/Flank/src/main/java/com/walmart/otto/tools/GcloudTool.java
+++ b/Flank/src/main/java/com/walmart/otto/tools/GcloudTool.java
@@ -36,6 +36,7 @@ public class GcloudTool extends Tool {
           "--type",
           "instrumentation",
           orchestratorFlag(),
+          autoGoogleLoginFlag(),
           "--app",
           bucket + getSimpleName(getAppAPK()),
           "--test",
@@ -78,6 +79,13 @@ public class GcloudTool extends Tool {
       return "--use-orchestrator";
     }
     return "--no-use-orchestrator";
+  }
+
+  private String autoGoogleLoginFlag() {
+    if (getConfigurator().disableAutoGoogleLogin()) {
+      return "--no-auto-google-login";
+    }
+    return "";
   }
 
   private String betaConfiguration() {

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ gcloud-path: The path to the glcoud binary
 gsutil-path: The path to the gsutil binary
 gcloud-bucket: The Google Cloud Storage bucket to use. If not specified Flank will create one.
 use-gcloud-beta: If gcloud beta should be used
+disable-google-login: If the argument `--no-auto-google-login` should be passed to the gcloud command line.
 
 aggregate-reports.enabled: Enable the experimental test aggregation feature. Requires fetch-bucket to be enabled. Disabled by default.
 aggregate-reports.xml: Generates and pushes to Google Cloud Storage an aggregated XML report


### PR DESCRIPTION
There are some issues with firebase test lab caused by play service and
auto-google-login. This adds a flag `disable-google-login` to
config.properties which allows you to disable auto google login.

When the flag is set, `--no-auto-google-login` is added to the command
line arguments to gcloud.