### PR TITLE
Improve the format for the --no-auto-google-login flag

### DIFF
--- a/Flank/src/main/java/com/walmart/otto/configurator/ConfigReader.java
+++ b/Flank/src/main/java/com/walmart/otto/configurator/ConfigReader.java
@@ -136,8 +136,8 @@ public class ConfigReader {
         configurator.setGenerateSplitVideo(Boolean.parseBoolean(value));
         break;
 
-      case "disable-google-login":
-        configurator.setDisableAutoGoogleLogin(Boolean.parseBoolean(value));
+      case "auto-google-login":
+        configurator.setAutoGoogleLogin(Boolean.parseBoolean(value));
         break;
 
       default:

--- a/Flank/src/main/java/com/walmart/otto/configurator/Configurator.java
+++ b/Flank/src/main/java/com/walmart/otto/configurator/Configurator.java
@@ -24,7 +24,7 @@ public class Configurator {
   private boolean fetchXMLFiles = true;
   private boolean debug = false;
   private boolean fetchBucket = false;
-  private boolean disableAutoGoogleLogin = false;
+  private boolean autoGoogleLogin = false;
   private int numShards = -1;
   private int shardIndex = -1;
   private int shardTimeout = 5;
@@ -193,12 +193,12 @@ public class Configurator {
     this.useGCloudBeta = useGCloudBeta;
   }
 
-  public boolean disableAutoGoogleLogin() {
-    return disableAutoGoogleLogin;
+  public boolean autoGoogleLogin() {
+    return autoGoogleLogin;
   }
 
-  public void setDisableAutoGoogleLogin(boolean disableAutoGoogleLogin) {
-    this.disableAutoGoogleLogin = disableAutoGoogleLogin;
+  public void setAutoGoogleLogin(boolean autoGoogleLogin) {
+    this.autoGoogleLogin = autoGoogleLogin;
   }
 
   private void setupDevices() {

--- a/Flank/src/main/java/com/walmart/otto/tools/GcloudTool.java
+++ b/Flank/src/main/java/com/walmart/otto/tools/GcloudTool.java
@@ -82,7 +82,7 @@ public class GcloudTool extends Tool {
   }
 
   private String autoGoogleLoginFlag() {
-    if (getConfigurator().disableAutoGoogleLogin()) {
+    if (!getConfigurator().autoGoogleLogin()) {
       return "--no-auto-google-login";
     }
     return "";

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ gcloud-path: The path to the glcoud binary
 gsutil-path: The path to the gsutil binary
 gcloud-bucket: The Google Cloud Storage bucket to use. If not specified Flank will create one.
 use-gcloud-beta: If gcloud beta should be used
-disable-google-login: If the argument `--no-auto-google-login` should be passed to the gcloud command line.
+auto-google-login: Automatically log into the test device using a preconfigured Google account before beginning the test. False by default.
 
 aggregate-reports.enabled: Enable the experimental test aggregation feature. Requires fetch-bucket to be enabled. Disabled by default.
 aggregate-reports.xml: Generates and pushes to Google Cloud Storage an aggregated XML report
@@ -93,6 +93,7 @@ numShards=
 shardIndex=
 debug-prints=false  
 fetch-xml-files=true
+auto-google-login=true
 fetch-bucket=false
 gcloud-path=
 gsutil-path=


### PR DESCRIPTION
[Negative booleans are confusing.](https://www.quora.com/Is-it-bad-practice-to-have-a-negative-boolean-variable-name-like-didntLose-instead-of-didLose)

Also specifies what the default value is, in the README.