### PR TITLE
Fix bug parsing time.

### DIFF
--- a/Flank/src/main/java/com/walmart/otto/tools/GcloudTool.java
+++ b/Flank/src/main/java/com/walmart/otto/tools/GcloudTool.java
@@ -135,8 +135,8 @@ public class GcloudTool extends Tool {
     for (String line : errorStreamList) {
       if (line.contains("More details are available")) {
         resultsLink = line;
-      } else if (line.contains("Test time=")) {
-        String[] timeLine = line.split(Pattern.quote("time="));
+      } else if (line.contains("Test time = ")) {
+        String[] timeLine = line.split(Pattern.quote("time = "));
         latestExecutionTime = Integer.parseInt(timeLine[1].replaceAll("\\D+", ""));
         TimeReporter.addExecutionTime(Integer.parseInt(timeLine[1].replaceAll("\\D+", "")));
       } else if (line.contains("ERROR")) {

--- a/release_notes.md
+++ b/release_notes.md
@@ -2,7 +2,7 @@ Release notes for flank
 
 # next (unreleased)
 
--
+- [Fix bug parsing test duration - **runningcode**](https://github.com/TestArmada/flank/pull/158)
 
 # 2.0.2
 


### PR DESCRIPTION
It seems the format of the time changed from `Test time=8 (secs)`
to `Test time = 8 (secs)`.

Fixes #154