### PR TITLE
Fix duplicate OnlyTestIdentifiers (#218)

### DIFF
--- a/cloud_testing/kotlin_poc/src/main/kotlin/ftl/gc/GcIosTestMatrix.kt
+++ b/cloud_testing/kotlin_poc/src/main/kotlin/ftl/gc/GcIosTestMatrix.kt
@@ -1,6 +1,5 @@
 package ftl.gc
 
-import com.dd.plist.NSDictionary
 import com.google.api.services.testing.Testing
 import com.google.api.services.testing.model.*
 import ftl.config.YamlConfig
@@ -17,13 +16,13 @@ object GcIosTestMatrix {
             testZipGcsPath: String,
             runGcsPath: String,
             testShardsIndex: Int,
-            xcTestParsed: NSDictionary,
             config: YamlConfig): Testing.Projects.TestMatrices.Create {
 
         val matrixGcsSuffix = join(runGcsPath, Utils.uniqueObjectName())
         val matrixGcsPath = join(config.rootGcsBucket, matrixGcsSuffix)
         val methods = config.testShardChunks.elementAt(testShardsIndex)
 
+        val xcTestParsed = Xctestrun.parse(config.xctestrunFile)
         val generatedXctestrun = Xctestrun.rewrite(xcTestParsed, methods)
         val xctestrunFileGcsPath = GcStorage.uploadXCTestFile(config, matrixGcsSuffix, generatedXctestrun)
 

--- a/cloud_testing/kotlin_poc/src/main/kotlin/ftl/run/IosTestRunner.kt
+++ b/cloud_testing/kotlin_poc/src/main/kotlin/ftl/run/IosTestRunner.kt
@@ -9,7 +9,6 @@ import ftl.ios.IosCatalog
 import ftl.json.MatrixMap
 import kotlinx.coroutines.experimental.Deferred
 import kotlinx.coroutines.experimental.async
-import xctest.Xctestrun
 
 object IosTestRunner : GenericTestRunner {
 
@@ -27,8 +26,6 @@ object IosTestRunner : GenericTestRunner {
                 .setLocale("en_US") // FTL iOS doesn't currently support other locales or orientations
                 .setOrientation("portrait")
 
-        val xcTestParsed = Xctestrun.parse(config.xctestrunFile)
-
         val jobs = arrayListOf<Deferred<TestMatrix>>()
         val runCount = config.testRuns
         val repeatShard = config.testShardChunks.size
@@ -45,7 +42,6 @@ object IosTestRunner : GenericTestRunner {
                             testZipGcsPath = xcTestGcsPath,
                             runGcsPath = runGcsPath,
                             testShardsIndex = testShardsIndex,
-                            xcTestParsed = xcTestParsed,
                             config = config).execute()
                 }
             }


### PR DESCRIPTION
The same object was being passed and mutated in each coroutine, causing more
than one set after all the removes. Having each routine operate on their own
copy eliminates this race condition.

Fix #218