### PR TITLE
Allow xctestrunZip to be specified as a gcs path

### DIFF
--- a/cloud_testing/kotlin_poc/src/main/kotlin/ftl/config/YamlConfig.kt
+++ b/cloud_testing/kotlin_poc/src/main/kotlin/ftl/config/YamlConfig.kt
@@ -89,7 +89,9 @@ class YamlConfig(
     }
 
     private fun validateIos() {
-        assertFileExists(xctestrunZip, "xctestrunZip")
+        if (!xctestrunZip.startsWith("gs://")) {
+            assertFileExists(xctestrunZip, "xctestrunZip")
+        }
         assertFileExists(xctestrunFile, "xctestrunFile")
 
         calculateShards(Xctestrun.findTestNames(xctestrunFile))

--- a/cloud_testing/kotlin_poc/src/main/kotlin/ftl/run/IosTestRunner.kt
+++ b/cloud_testing/kotlin_poc/src/main/kotlin/ftl/run/IosTestRunner.kt
@@ -19,7 +19,11 @@ object IosTestRunner : GenericTestRunner {
     override suspend fun runTests(config: YamlConfig): MatrixMap {
         val (stopwatch, runGcsPath) = beforeRunTests()
 
-        val xcTestGcsPath = GcStorage.uploadXCTestZip(config, runGcsPath)
+        val xcTestGcsPath = if (config.xctestrunZip.startsWith("gs://")) {
+            config.xctestrunZip
+        } else {
+            GcStorage.uploadXCTestZip(config, runGcsPath)
+        }
 
         val iosDevice = IosDevice()
                 .setIosModelId(IosCatalog.model("iphone8"))


### PR DESCRIPTION
Update validation to allow the gcs path, and skip uploading to gcs if the path
already points to gcs instead of a local zip file.

fix #217