### PR TITLE
Filter invalid devices from iOS catalog

### DIFF
--- a/cloud_testing/kotlin_poc/src/main/kotlin/ftl/cli/DoctorCommand.kt
+++ b/cloud_testing/kotlin_poc/src/main/kotlin/ftl/cli/DoctorCommand.kt
@@ -18,7 +18,9 @@ import picocli.CommandLine.Option
 class DoctorCommand : Runnable {
     override fun run() {
         runBlocking {
-            IosCatalog.model("iphone8")
+            if (!IosCatalog.supported("iphone8", "11.2")) {
+                throw RuntimeException("iPhone 8 with iOS 11.2 is unexpectedly unsupported")
+            }
             println("Flank successfully connected to iOS catalog")
         }
     }

--- a/cloud_testing/kotlin_poc/src/main/kotlin/ftl/ios/IosCatalog.kt
+++ b/cloud_testing/kotlin_poc/src/main/kotlin/ftl/ios/IosCatalog.kt
@@ -19,26 +19,6 @@ Request access for your project via the following form:
 If this project has already been granted access, please email ftl-ios-feedback@google.com for support.""", e)
         }
     }
-    private val iosModelIds by lazy {
-        iosDeviceCatalog.models
-                .filter { it.supportedVersionIds?.isNotEmpty() ?: false }
-                .map { it.id }
-    }
-    private val iosVersionIds by lazy { iosDeviceCatalog.versions.map { it.id } }
-
-    fun model(modelId: String): String {
-        if (!iosModelIds.contains(modelId)) {
-            throw RuntimeException("Invalid iOS modelId '$modelId'.\nValid models are: $iosModelIds")
-        }
-        return modelId
-    }
-
-    fun version(versionId: String): String {
-        if (!iosVersionIds.contains(versionId)) {
-            throw RuntimeException("Invalid iOS versionId '$versionId'.\nValid versions are: $iosVersionIds")
-        }
-        return versionId
-    }
 
     fun supported(modelId: String, versionId: String): Boolean {
         val model = iosDeviceCatalog.models.find { it.id == modelId }

--- a/cloud_testing/kotlin_poc/src/main/kotlin/ftl/ios/IosCatalog.kt
+++ b/cloud_testing/kotlin_poc/src/main/kotlin/ftl/ios/IosCatalog.kt
@@ -19,10 +19,13 @@ Request access for your project via the following form:
 If this project has already been granted access, please email ftl-ios-feedback@google.com for support.""", e)
         }
     }
-    private val iosModelIds by lazy { iosDeviceCatalog.models.map { it.id } }
+    private val iosModelIds by lazy {
+        iosDeviceCatalog.models
+                .filter { it.supportedVersionIds?.isNotEmpty() ?: false }
+                .map { it.id }
+    }
     private val iosVersionIds by lazy { iosDeviceCatalog.versions.map { it.id } }
 
-    // todo: check supportedVersionIds once the API returns that for each model.
     fun model(modelId: String): String {
         if (!iosModelIds.contains(modelId)) {
             throw RuntimeException("Invalid iOS modelId '$modelId'.\nValid models are: $iosModelIds")
@@ -35,5 +38,10 @@ If this project has already been granted access, please email ftl-ios-feedback@g
             throw RuntimeException("Invalid iOS versionId '$versionId'.\nValid versions are: $iosVersionIds")
         }
         return versionId
+    }
+
+    fun supported(modelId: String, versionId: String): Boolean {
+        val model = iosDeviceCatalog.models.find { it.id == modelId }
+        return model?.supportedVersionIds?.contains(versionId) ?: false
     }
 }

--- a/cloud_testing/kotlin_poc/src/main/kotlin/ftl/run/IosTestRunner.kt
+++ b/cloud_testing/kotlin_poc/src/main/kotlin/ftl/run/IosTestRunner.kt
@@ -26,8 +26,8 @@ object IosTestRunner : GenericTestRunner {
         }
 
         val iosDevice = IosDevice()
-                .setIosModelId(IosCatalog.model("iphone8"))
-                .setIosVersionId(IosCatalog.version("11.2"))
+                .setIosModelId("iphone8")
+                .setIosVersionId("11.2")
                 .setLocale("en_US") // FTL iOS doesn't currently support other locales or orientations
                 .setOrientation("portrait")
 

--- a/cloud_testing/kotlin_poc/src/test/kotlin/ftl/ios/IosCatalogTest.kt
+++ b/cloud_testing/kotlin_poc/src/test/kotlin/ftl/ios/IosCatalogTest.kt
@@ -1,49 +1,16 @@
 package ftl.ios
 
-import junit.framework.Assert.assertEquals
-import org.junit.Rule
+import org.junit.Assert.assertEquals
 import org.junit.Test
-import org.junit.rules.ExpectedException
 
 class IosCatalogTest {
-
-    @get:Rule
-    var thrown = ExpectedException.none()!!
 
     // iOS API requires authorization. Bitrise job is run without credentials for security reasons.
     // Skip tests that require auth when running on bitrise.
     private val bitrise = System.getenv("BITRISE_IO") != null
 
     @Test
-    fun validatesModelAndVersion() {
-        if (bitrise) return
-
-        IosCatalog.model("iphone8")
-        IosCatalog.version("11.2")
-    }
-
-    @Test
-    fun rejectsInvalidModel() {
-        if (bitrise) return
-
-        thrown.expect(RuntimeException::class.java)
-        thrown.expectMessage("Invalid iOS modelId")
-
-        IosCatalog.model("iphone88")
-    }
-
-    @Test
-    fun rejectsInvalidVersion() {
-        if (bitrise) return
-
-        thrown.expect(RuntimeException::class.java)
-        thrown.expectMessage("Invalid iOS versionId")
-
-        IosCatalog.version("11.22")
-    }
-
-    @Test
-    fun validatesSupportedModelAndVersion() {
+    fun supported() {
         if (bitrise) return
 
         assertEquals(false, IosCatalog.supported("bogus", "11.2"))

--- a/cloud_testing/kotlin_poc/src/test/kotlin/ftl/ios/IosCatalogTest.kt
+++ b/cloud_testing/kotlin_poc/src/test/kotlin/ftl/ios/IosCatalogTest.kt
@@ -1,5 +1,6 @@
 package ftl.ios
 
+import junit.framework.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.ExpectedException
@@ -39,5 +40,14 @@ class IosCatalogTest {
         thrown.expectMessage("Invalid iOS versionId")
 
         IosCatalog.version("11.22")
+    }
+
+    @Test
+    fun validatesSupportedModelAndVersion() {
+        if (bitrise) return
+
+        assertEquals(false, IosCatalog.supported("bogus", "11.2"))
+        assertEquals(false, IosCatalog.supported("iphone8", "bogus"))
+        assertEquals(true, IosCatalog.supported("iphone8", "11.2"))
     }
 }


### PR DESCRIPTION
If supportedVersionIds is null or empty, then don't include it in iosModelIds.
Also add supported method to check if a model/version pair is supported.

Fix #188 