### PR TITLE
Add device matrix for ios

### DIFF
--- a/cloud_testing/kotlin_poc/src/main/kotlin/ftl/config/YamlConfig.kt
+++ b/cloud_testing/kotlin_poc/src/main/kotlin/ftl/config/YamlConfig.kt
@@ -7,6 +7,7 @@ import com.google.cloud.ServiceOptions
 import com.google.common.math.IntMath
 import com.linkedin.dex.parser.DexParser
 import ftl.config.FtlConstants.useMock
+import ftl.ios.IosCatalog
 import ftl.util.Utils.fatalError
 import xctest.Xctestrun
 import java.io.File
@@ -68,6 +69,12 @@ class YamlConfig(
         }
     }
 
+    private fun assertIosDeviceSupported(device: Device) {
+        if (!IosCatalog.supported(device.model, device.version)) {
+            fatalError("iOS ${device.version} on ${device.model} is not a supported device")
+        }
+    }
+
     private fun validateAndroid() {
         assertFileExists(appApk, "appApk")
         assertFileExists(testApk, "testApk")
@@ -93,6 +100,8 @@ class YamlConfig(
             assertFileExists(xctestrunZip, "xctestrunZip")
         }
         assertFileExists(xctestrunFile, "xctestrunFile")
+
+        for (device in devices) assertIosDeviceSupported(device)
 
         calculateShards(Xctestrun.findTestNames(xctestrunFile))
     }
@@ -174,7 +183,8 @@ class YamlConfig(
                 testTimeoutMinutes: $testTimeoutMinutes,
                 testRuns: $testRuns,
                 waitForResults: $waitForResults,
-                limitBreak: $limitBreak
+                limitBreak: $limitBreak,
+                devices: $devices
                 """
         } else {
             return """YamlConfig

--- a/cloud_testing/kotlin_poc/src/main/kotlin/ftl/config/YamlConfig.kt
+++ b/cloud_testing/kotlin_poc/src/main/kotlin/ftl/config/YamlConfig.kt
@@ -101,7 +101,7 @@ class YamlConfig(
         }
         assertFileExists(xctestrunFile, "xctestrunFile")
 
-        for (device in devices) assertIosDeviceSupported(device)
+        devices.forEach { device -> assertIosDeviceSupported(device) }
 
         calculateShards(Xctestrun.findTestNames(xctestrunFile))
     }

--- a/cloud_testing/kotlin_poc/src/main/kotlin/ftl/gc/GcIosMatrix.kt
+++ b/cloud_testing/kotlin_poc/src/main/kotlin/ftl/gc/GcIosMatrix.kt
@@ -1,0 +1,18 @@
+package ftl.gc
+
+import com.google.api.services.testing.model.IosDevice
+import com.google.api.services.testing.model.IosDeviceList
+import ftl.config.Device
+
+object GcIosMatrix {
+
+    fun build(deviceList: List<Device>): IosDeviceList = IosDeviceList().setIosDevices(
+            deviceList.map {
+                IosDevice()
+                        .setIosModelId(it.model)
+                        .setIosVersionId(it.version)
+                        .setLocale("en_US") // FTL iOS doesn't currently support other locales or orientations
+                        .setOrientation("portrait")
+            }
+    )
+}

--- a/cloud_testing/kotlin_poc/src/main/kotlin/ftl/gc/GcIosTestMatrix.kt
+++ b/cloud_testing/kotlin_poc/src/main/kotlin/ftl/gc/GcIosTestMatrix.kt
@@ -13,7 +13,7 @@ import java.util.concurrent.TimeUnit
 object GcIosTestMatrix {
 
     fun build(
-            iosDevice: IosDevice,
+            iosDeviceList: IosDeviceList,
             testZipGcsPath: String,
             runGcsPath: String,
             testShardsIndex: Int,
@@ -46,9 +46,7 @@ object GcIosTestMatrix {
         val resultStorage = ResultStorage()
                 .setGoogleCloudStorage(GoogleCloudStorage().setGcsPath(matrixGcsPath))
 
-        val environmentMatrix = EnvironmentMatrix()
-                .setIosDeviceList(
-                        IosDeviceList().setIosDevices(listOf(iosDevice)))
+        val environmentMatrix = EnvironmentMatrix().setIosDeviceList(iosDeviceList)
 
         val testMatrix = TestMatrix()
                 .setTestSpecification(testSpec)

--- a/cloud_testing/kotlin_poc/src/main/kotlin/ftl/run/IosTestRunner.kt
+++ b/cloud_testing/kotlin_poc/src/main/kotlin/ftl/run/IosTestRunner.kt
@@ -1,11 +1,10 @@
 package ftl.run
 
-import com.google.api.services.testing.model.IosDevice
 import com.google.api.services.testing.model.TestMatrix
 import ftl.config.YamlConfig
+import ftl.gc.GcIosMatrix
 import ftl.gc.GcIosTestMatrix
 import ftl.gc.GcStorage
-import ftl.ios.IosCatalog
 import ftl.json.MatrixMap
 import kotlinx.coroutines.experimental.Deferred
 import kotlinx.coroutines.experimental.async
@@ -25,11 +24,7 @@ object IosTestRunner : GenericTestRunner {
             GcStorage.uploadXCTestZip(config, runGcsPath)
         }
 
-        val iosDevice = IosDevice()
-                .setIosModelId("iphone8")
-                .setIosVersionId("11.2")
-                .setLocale("en_US") // FTL iOS doesn't currently support other locales or orientations
-                .setOrientation("portrait")
+        val iosDeviceList = GcIosMatrix.build(config.devices)
 
         val xcTestParsed = Xctestrun.parse(config.xctestrunFile)
 
@@ -45,7 +40,7 @@ object IosTestRunner : GenericTestRunner {
             repeat(repeatShard) { testShardsIndex ->
                 jobs += async {
                     GcIosTestMatrix.build(
-                            iosDevice = iosDevice,
+                            iosDeviceList = iosDeviceList,
                             testZipGcsPath = xcTestGcsPath,
                             runGcsPath = runGcsPath,
                             testShardsIndex = testShardsIndex,


### PR DESCRIPTION
The devices specified in the yaml config are validated against the catalog of
supported ios devices, and passed to the gc api.

Fix #193