### PR TITLE
Add end-to-end iOS test

### DIFF
--- a/cloud_testing/kotlin_poc/.gitignore
+++ b/cloud_testing/kotlin_poc/.gitignore
@@ -1,2 +1,3 @@
 results
 *.jar
+tmp

--- a/cloud_testing/kotlin_poc/build.gradle.kts
+++ b/cloud_testing/kotlin_poc/build.gradle.kts
@@ -89,6 +89,7 @@ dependencies {
     compile("com.fasterxml.jackson.module:jackson-module-kotlin:${Versions.JACKSON}")
     compile("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${Versions.JACKSON}")
 
+    testImplementation("org.jsoup:jsoup:1.11.3")
     testImplementation(Libs.JUNIT)
     // http://stefanbirkner.github.io/system-rules/index.html
     testImplementation("com.github.stefanbirkner:system-rules:1.17.1")

--- a/cloud_testing/kotlin_poc/src/test/kotlin/ftl/MainTest.kt
+++ b/cloud_testing/kotlin_poc/src/test/kotlin/ftl/MainTest.kt
@@ -6,7 +6,7 @@ import ftl.run.TestRunner
 import kotlinx.coroutines.experimental.runBlocking
 import org.junit.Test
 
-class MainTest {
+class MainTest : TestArtifact() {
 
     init {
         FtlConstants.useMock = true
@@ -15,6 +15,14 @@ class MainTest {
     @Test
     fun mockedTestRun() {
         val config = YamlConfig.load("src/test/kotlin/ftl/fixtures/flank.yml")
+        runBlocking {
+            TestRunner.newRun(config)
+        }
+    }
+
+    @Test
+    fun mockedIosTestRun() {
+        val config = YamlConfig.load("src/test/kotlin/ftl/fixtures/flank.ios.yml")
         runBlocking {
             TestRunner.newRun(config)
         }

--- a/cloud_testing/kotlin_poc/src/test/kotlin/ftl/TestArtifact.kt
+++ b/cloud_testing/kotlin_poc/src/test/kotlin/ftl/TestArtifact.kt
@@ -1,0 +1,93 @@
+package ftl
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.nodes.Element
+import java.io.File
+import java.util.concurrent.TimeUnit
+import kotlin.math.pow
+import xctest.Bash
+
+abstract class TestArtifact {
+    internal val fixturesPath = "./src/test/kotlin/ftl/fixtures/tmp"
+
+    init {
+        val assetLink = remoteAssetLink()
+        if (updateRequired(assetLink)) {
+            updateFixtures(assetLink)
+        }
+    }
+
+    private fun getHtml(): Document {
+        val githubUrl = "https://github.com/Flank/test_artifacts/releases/latest"
+        val maxRetries = 6
+        repeat(maxRetries) { attempt ->
+            try {
+                return Jsoup.connect(githubUrl).get()
+            } catch (e: Exception) {
+                wait(attempt)
+            }
+        }
+        throw RuntimeException("Unable to connect to '$githubUrl' after $maxRetries attempts!")
+    }
+
+    private fun wait(attempt: Int) {
+        // use AWS retry_backoff:
+        // https://github.com/aws/aws-sdk-ruby/blob/a2e85a4db05f52804a1ec9bc1552732c7bb8a7b8/aws-sdk-core/lib/aws-sdk-core/plugins/retry_errors.rb#L16
+        val backoff = 2f.pow(attempt) * 0.3
+        sleep(seconds = minOf(5.minutes, backoff.toLong()))
+    }
+
+    private fun sleep(seconds: Long) {
+        Thread.sleep(seconds.millis)
+    }
+
+    private fun remoteAssetLink(): Element {
+        val doc = getHtml()
+        val downloadLinks = doc.select("li.d-block > a")
+        return downloadLinks.find {
+            it.attr("href").endsWith(".zip") && it.attr("href").contains("releases/download")
+        } ?: throw RuntimeException("Download link not found in html!")
+    }
+
+    private fun updateRequired(remoteAssetLink: Element): Boolean {
+        val remoteAssetName = remoteAssetLink.attr("href").split("/").last()
+        val fixtures = File(fixturesPath)
+        if (!fixtures.exists()) return true
+        fixtures.listFiles().find {
+            it.name == remoteAssetName
+        } ?: return true
+        return false
+    }
+
+    private fun updateFixtures(remoteAssetLink: Element) {
+        val fixtures = File(fixturesPath)
+        if (fixtures.exists()) fixtures.deleteRecursively()
+        fixtures.mkdirs()
+
+        val downloadUrl = "https://github.com${remoteAssetLink.attr("href")}"
+        val assetName = remoteAssetLink.attr("href").split("/").last()
+        val zipPath = "${fixtures.path}/$assetName"
+        val curl = """
+            curl
+            --connect-timeout 5
+            --max-time 300
+            --retry 5
+            --retry-delay 0
+            --retry-max-time 1000
+            -L "$downloadUrl"
+            -o "$zipPath"
+            """.trimIndent().replace("\n", " ")
+        Bash.execute(curl)
+
+        val unzip = "unzip \"$zipPath\" -d \"${fixtures.path}\""
+        Bash.execute(unzip)
+        File(zipPath).copyTo(File("${fixtures.path}/EarlGreyExample.zip"))
+    }
+}
+
+private val Int.minutes
+    get() = TimeUnit.MINUTES.toSeconds(this.toLong())
+
+private val Long.millis
+    get() = TimeUnit.SECONDS.toMillis(this)

--- a/cloud_testing/kotlin_poc/src/test/kotlin/ftl/fixtures/flank.ios.yml
+++ b/cloud_testing/kotlin_poc/src/test/kotlin/ftl/fixtures/flank.ios.yml
@@ -1,0 +1,17 @@
+xctestrunZip: ./src/test/kotlin/ftl/fixtures/tmp/EarlGreyExample.zip
+xctestrunFile: ./src/test/kotlin/ftl/fixtures/tmp/EarlGreyExampleMixedTests_iphoneos11.2-arm64.xctestrun
+rootGcsBucket: tmp_bucket_2
+disablePerformanceMetrics: true
+disableVideoRecording: false
+testTimeoutMinutes: 60
+testShards: 1
+testRuns: 1
+limitBreak: false
+waitForResults: true
+testMethods:
+  - EarlGreyExampleMixedTests/testBasicSelection
+devices:
+  - model: iphone8
+    version: 11.2
+    orientation: portrait
+    locale: en_US

--- a/cloud_testing/mock_server/build.gradle.kts
+++ b/cloud_testing/mock_server/build.gradle.kts
@@ -64,8 +64,10 @@ dependencies {
     // https://github.com/linkedin/dex-test-parser/releases
     compile("com.linkedin.dextestparser:parser:1.1.0")
 
+    // NOTE: iOS support isn't in the public artifact. Use testing jar generated from the private gcloud CLI json
     // https://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.google.apis%22%20AND%20a%3A%22google-api-services-testing%22
-    compile("com.google.apis:google-api-services-testing:v1-rev23-1.23.0")
+    // compile("com.google.apis:google-api-services-testing:v1-rev23-1.23.0")
+    compile(project(":testing"))
 
     compile(kotlin("stdlib-jre8", Deps.kotlinVersion))
     testCompile("junit:junit:4.12")

--- a/cloud_testing/mock_server/src/main/kotlin/ftl/Main.kt
+++ b/cloud_testing/mock_server/src/main/kotlin/ftl/Main.kt
@@ -35,6 +35,33 @@ object Main {
                 register(ContentType.Application.Json, GsonConverter(gson))
             }
             routing {
+                get("/v1/testEnvironmentCatalog/ios") {
+                    println("Responding to GET ${call.request.uri}")
+
+                    val version = IosVersion()
+                    version.id = "11.2"
+                    version.majorVersion = 11
+                    version.minorVersion = 2
+
+                    val iphone8 = IosModel()
+                    iphone8.id = "iphone8"
+                    iphone8.name = "iPhone 8"
+                    iphone8.supportedVersionIds = listOf("11.2")
+
+                    val iphonex = IosModel()
+                    iphonex.id = "iphonex"
+                    iphonex.name = "iPhone X"
+                    iphonex.supportedVersionIds = listOf("11.2")
+
+                    val iosCatalog = IosDeviceCatalog()
+                            .setVersions(listOf(version))
+                            .setModels(listOf(iphone8, iphonex))
+
+                    val catalog = TestEnvironmentCatalog()
+                    catalog.iosDeviceCatalog = iosCatalog
+
+                    call.respond(catalog)
+                }
                 get("/v1/projects/{projectId}/testMatrices/{matrixIdCounter}") {
                     println("Responding to GET ${call.request.uri}")
                     val projectId = call.parameters["projectId"]


### PR DESCRIPTION
While this does not make any assertions along the way, it ensures the process
completes without exception.
This also adds the mock server response for ios device catalog and downloads
temporary fixture build artifacts to tests against.

Fixes #227 