### PR TITLE
Update cost estimates by device form

### DIFF
--- a/cloud_testing/kotlin_poc/src/main/kotlin/ftl/android/AndroidCatalog.kt
+++ b/cloud_testing/kotlin_poc/src/main/kotlin/ftl/android/AndroidCatalog.kt
@@ -27,6 +27,11 @@ object AndroidCatalog {
 
         return SupportedDeviceConfig
     }
+
+    fun isVirtualDevice(modelId: String): Boolean {
+        val form = androidDeviceCatalog.models.find { it.id == modelId }?.form ?: "PHYSICAL"
+        return form == "VIRTUAL"
+    }
 }
 
 sealed class DeviceConfigCheck

--- a/cloud_testing/kotlin_poc/src/main/kotlin/ftl/android/AndroidCatalog.kt
+++ b/cloud_testing/kotlin_poc/src/main/kotlin/ftl/android/AndroidCatalog.kt
@@ -1,5 +1,6 @@
 package ftl.android
 
+import com.google.api.services.testing.model.AndroidDevice
 import ftl.gc.GcTesting
 
 
@@ -28,7 +29,8 @@ object AndroidCatalog {
         return SupportedDeviceConfig
     }
 
-    fun isVirtualDevice(modelId: String): Boolean {
+    fun isVirtualDevice(device: AndroidDevice?): Boolean {
+        val modelId = device?.androidModelId ?: return false
         val form = androidDeviceCatalog.models.find { it.id == modelId }?.form ?: "PHYSICAL"
         return form == "VIRTUAL"
     }

--- a/cloud_testing/kotlin_poc/src/main/kotlin/ftl/json/SavedMatrix.kt
+++ b/cloud_testing/kotlin_poc/src/main/kotlin/ftl/json/SavedMatrix.kt
@@ -50,8 +50,7 @@ class SavedMatrix(matrix: TestMatrix) {
         matrix.testExecutions.forEach {
             val step = GcToolResults.getResults(it.toolResultsStep)
             val billableMinutes = Billing.billableMinutes(step.testExecutionStep.testTiming.testProcessDuration.seconds)
-            val androidDevice = it.environment.androidDevice
-            if (androidDevice != null && AndroidCatalog.isVirtualDevice(androidDevice.androidModelId)) {
+            if (AndroidCatalog.isVirtualDevice(it.environment.androidDevice)) {
                 billableVirtualMinutes += billableMinutes
             } else {
                 billablePhysicalMinutes += billableMinutes

--- a/cloud_testing/kotlin_poc/src/main/kotlin/ftl/json/SavedMatrix.kt
+++ b/cloud_testing/kotlin_poc/src/main/kotlin/ftl/json/SavedMatrix.kt
@@ -1,6 +1,7 @@
 package ftl.json
 
 import com.google.api.services.testing.model.TestMatrix
+import ftl.android.AndroidCatalog
 import ftl.gc.GcToolResults
 import ftl.util.Billing
 import ftl.util.MatrixState.FINISHED
@@ -16,9 +17,8 @@ class SavedMatrix(matrix: TestMatrix) {
     var webLink: String = matrix.webLink()
     var downloaded = false
 
-    var billableMinutes: Long = 0
-    private var testDurationSeconds: Long = 0
-    private var runDurationSeconds: Long = 0
+    var billableVirtualMinutes: Long = 0
+    var billablePhysicalMinutes: Long = 0
     var outcome: String = ""
 
     init {
@@ -45,12 +45,17 @@ class SavedMatrix(matrix: TestMatrix) {
     }
 
     private fun finished(matrix: TestMatrix) {
-        val toolResultsStep = matrix.firstToolResults()
-        if (toolResultsStep != null) {
-            val step = GcToolResults.getResults(toolResultsStep)
-            testDurationSeconds = step.testExecutionStep.testTiming.testProcessDuration.seconds
-            runDurationSeconds = step.runDuration.seconds
-            billableMinutes = Billing.billableMinutes(testDurationSeconds)
+        billableVirtualMinutes = 0
+        billablePhysicalMinutes = 0
+        matrix.testExecutions.forEach {
+            val step = GcToolResults.getResults(it.toolResultsStep)
+            val billableMinutes = Billing.billableMinutes(step.testExecutionStep.testTiming.testProcessDuration.seconds)
+            val androidDevice = it.environment.androidDevice
+            if (androidDevice != null && AndroidCatalog.isVirtualDevice(androidDevice.androidModelId)) {
+                billableVirtualMinutes += billableMinutes
+            } else {
+                billablePhysicalMinutes += billableMinutes
+            }
             outcome = step.outcome.summary
         }
     }

--- a/cloud_testing/kotlin_poc/src/main/kotlin/ftl/reports/CostReport.kt
+++ b/cloud_testing/kotlin_poc/src/main/kotlin/ftl/reports/CostReport.kt
@@ -16,22 +16,32 @@ Calculates cost based on the matrix map. Always run.
 Example:
 
 
-Billable time:	69h 51m
-Billable minutes:	4191
-Physical device cost:	$349.25
-Virtual  device cost:	$69.85
+Physical devices
+  Billable time:  35h 29m
+  Billable minutes:   2129
+  Cost:   $177.42
+Virtual devices
+  Billable time:  34h 22m
+  Billable minutes:   2062
+  Cost:   $34.37
+Total
+  Billable time:  69h 51m
+  Billable minutes:   4191
+  Cost:   $211.79
 
  */
 object CostReport : IReport {
 
     private fun estimate(matrices: MatrixMap): String {
-        var totalBillableMinutes = 0L
+        var totalBillableVirtualMinutes = 0L
+        var totalBillablePhysicalMinutes = 0L
 
         matrices.map.values.forEach {
-            totalBillableMinutes += it.billableMinutes
+            totalBillableVirtualMinutes += it.billableVirtualMinutes
+            totalBillablePhysicalMinutes += it.billablePhysicalMinutes
         }
 
-        return Billing.estimateCosts(totalBillableMinutes)
+        return Billing.estimateCosts(totalBillableVirtualMinutes, totalBillablePhysicalMinutes)
     }
 
     private fun generate(matrices: MatrixMap): String {

--- a/cloud_testing/kotlin_poc/src/test/kotlin/ftl/android/AndroidCatalogTest.kt
+++ b/cloud_testing/kotlin_poc/src/test/kotlin/ftl/android/AndroidCatalogTest.kt
@@ -1,5 +1,6 @@
 package ftl.android
 
+import com.google.api.services.testing.model.AndroidDevice
 import ftl.config.FtlConstants
 import junit.framework.Assert.assertEquals
 import org.hamcrest.CoreMatchers.instanceOf
@@ -25,8 +26,13 @@ class AndroidCatalogTest {
 
     @Test
     fun validateIsVirtualDevice() {
-        assertEquals(true, AndroidCatalog.isVirtualDevice("NexusLowRes"))
-        assertEquals(false, AndroidCatalog.isVirtualDevice("shamu"))
-        assertEquals(false, AndroidCatalog.isVirtualDevice("ios"))
+        val nexus = AndroidDevice()
+        nexus.androidModelId = "NexusLowRes"
+        val shamu = AndroidDevice()
+        shamu.androidModelId = "shamu"
+
+        assertEquals(true, AndroidCatalog.isVirtualDevice(nexus))
+        assertEquals(false, AndroidCatalog.isVirtualDevice(shamu))
+        assertEquals(false, AndroidCatalog.isVirtualDevice(null))
     }
 }

--- a/cloud_testing/kotlin_poc/src/test/kotlin/ftl/android/AndroidCatalogTest.kt
+++ b/cloud_testing/kotlin_poc/src/test/kotlin/ftl/android/AndroidCatalogTest.kt
@@ -1,5 +1,6 @@
 package ftl.android
 
+import ftl.config.FtlConstants
 import junit.framework.Assert.assertEquals
 import org.hamcrest.CoreMatchers.instanceOf
 import org.junit.Assert.assertThat
@@ -10,12 +11,12 @@ import org.junit.rules.ExpectedException
 
 class AndroidCatalogTest {
 
-    private val bitrise = System.getenv("BITRISE_IO") != null
+    init {
+        FtlConstants.useMock = true
+    }
 
     @Test
     fun validateDeviceConfig() {
-        if (bitrise) return
-
         assertEquals(UnsupportedModelId, AndroidCatalog.supportedDeviceConfig("ios", "23"))
         assertEquals(UnsupportedVersionId, AndroidCatalog.supportedDeviceConfig("NexusLowRes", "twenty-three"))
         assertEquals(IncompatibleModelVersion, AndroidCatalog.supportedDeviceConfig("NexusLowRes", "21"))
@@ -24,8 +25,6 @@ class AndroidCatalogTest {
 
     @Test
     fun validateIsVirtualDevice() {
-        if (bitrise) return
-
         assertEquals(true, AndroidCatalog.isVirtualDevice("NexusLowRes"))
         assertEquals(false, AndroidCatalog.isVirtualDevice("shamu"))
         assertEquals(false, AndroidCatalog.isVirtualDevice("ios"))

--- a/cloud_testing/kotlin_poc/src/test/kotlin/ftl/android/AndroidCatalogTest.kt
+++ b/cloud_testing/kotlin_poc/src/test/kotlin/ftl/android/AndroidCatalogTest.kt
@@ -21,4 +21,13 @@ class AndroidCatalogTest {
         assertEquals(IncompatibleModelVersion, AndroidCatalog.supportedDeviceConfig("NexusLowRes", "21"))
         assertEquals(SupportedDeviceConfig, AndroidCatalog.supportedDeviceConfig("NexusLowRes", "23"))
     }
+
+    @Test
+    fun validateIsVirtualDevice() {
+        if (bitrise) return
+
+        assertEquals(true, AndroidCatalog.isVirtualDevice("NexusLowRes"))
+        assertEquals(false, AndroidCatalog.isVirtualDevice("shamu"))
+        assertEquals(false, AndroidCatalog.isVirtualDevice("ios"))
+    }
 }

--- a/cloud_testing/kotlin_poc/src/test/kotlin/ftl/ios/IosCatalogTest.kt
+++ b/cloud_testing/kotlin_poc/src/test/kotlin/ftl/ios/IosCatalogTest.kt
@@ -1,18 +1,17 @@
 package ftl.ios
 
+import ftl.config.FtlConstants
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class IosCatalogTest {
 
-    // iOS API requires authorization. Bitrise job is run without credentials for security reasons.
-    // Skip tests that require auth when running on bitrise.
-    private val bitrise = System.getenv("BITRISE_IO") != null
+    init {
+        FtlConstants.useMock = true
+    }
 
     @Test
     fun supported() {
-        if (bitrise) return
-
         assertEquals(false, IosCatalog.supported("bogus", "11.2"))
         assertEquals(false, IosCatalog.supported("iphone8", "bogus"))
         assertEquals(true, IosCatalog.supported("iphone8", "11.2"))

--- a/cloud_testing/kotlin_poc/src/test/kotlin/ftl/util/BillingTest.kt
+++ b/cloud_testing/kotlin_poc/src/test/kotlin/ftl/util/BillingTest.kt
@@ -1,0 +1,33 @@
+package ftl.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class BillingTest {
+
+    @Test
+    fun billableMinutes() {
+        assertEquals(1L, Billing.billableMinutes(0L))
+        assertEquals(1L, Billing.billableMinutes(60L))
+        assertEquals(2L, Billing.billableMinutes(61L))
+        assertEquals(60L, Billing.billableMinutes(3_555L))
+    }
+
+    @Test
+    fun estimateCosts() {
+        val expectedReport = """
+Physical devices
+  Billable time:	2h 3m
+  Billable minutes:	123
+  Cost:	$10.25
+Virtual devices
+  Billable time:	7h 36m
+  Billable minutes:	456
+  Cost:	$7.60
+Total
+  Billable time:	9h 39m
+  Billable minutes:	579
+  Cost:	$17.85""".trim()
+        assertEquals(expectedReport, Billing.estimateCosts(456L, 123L))
+    }
+}

--- a/cloud_testing/mock_server/src/main/kotlin/ftl/Main.kt
+++ b/cloud_testing/mock_server/src/main/kotlin/ftl/Main.kt
@@ -124,8 +124,15 @@ object Main {
                             .setExecutionId(matrixId)
                             .setStepId(matrixId)
 
+                    val device = AndroidDevice()
+                            .setAndroidModelId("NexusLowRes")
+
+                    val environment = Environment()
+                            .setAndroidDevice(device)
+
                     val testExecution = TestExecution()
                             .setToolResultsStep(toolResultsStep)
+                            .setEnvironment(environment)
 
                     val matrix = TestMatrix()
                             .setProjectId(projectId)


### PR DESCRIPTION
Calculate the estimated cost from each execution device based its form
(virtual or physical). This is also summing all devices instead of only looking
at the first.

fix #232 