### PR TITLE
Add cli arg for config file path

### DIFF
--- a/cloud_testing/kotlin_poc/src/main/kotlin/ftl/cli/RefreshCommand.kt
+++ b/cloud_testing/kotlin_poc/src/main/kotlin/ftl/cli/RefreshCommand.kt
@@ -20,10 +20,13 @@ Reads in the matrix_ids.json file. Refreshes any incomplete matrices.
 class RefreshCommand : Runnable {
     override fun run() {
         runBlocking {
-            val config = YamlConfig.load("./flank.yml")
+            val config = YamlConfig.load(configPath)
             TestRunner.refreshLastRun(config)
         }
     }
+
+    @Option(names = ["-c", "--config"], description = ["YAML config file path"])
+    var configPath: String = "./flank.yml"
 
     @Option(names = ["-h", "--help"], usageHelp = true, description = ["Prints this help message"])
     var usageHelpRequested: Boolean = false

--- a/cloud_testing/kotlin_poc/src/main/kotlin/ftl/cli/RunCommand.kt
+++ b/cloud_testing/kotlin_poc/src/main/kotlin/ftl/cli/RunCommand.kt
@@ -21,7 +21,7 @@ Configuration is read from flank.yml
 """])
 class RunCommand : Runnable {
     override fun run() {
-        val config = YamlConfig.load("./flank.yml")
+        val config = YamlConfig.load(configPath)
         if (shards > 0) config.testRuns = shards
         runBlocking {
             // Verify each device config
@@ -37,6 +37,9 @@ class RunCommand : Runnable {
 
         }
     }
+
+    @Option(names = ["-c", "--config"], description = ["YAML config file path"])
+    var configPath: String = "./flank.yml"
 
     @Option(names = ["-s", "--shards"], description = ["Amount of shards to use"])
     var shards: Int = -1


### PR DESCRIPTION
Both the refresh and run command get a -c/--config option for specifying the
flank.yml file to be used. Defaults to old value of "./flank.yml".