### PR TITLE
Always run

### DIFF
--- a/cloud_testing/kotlin_poc/src/main/kotlin/ftl/config/AndroidConfig.kt
+++ b/cloud_testing/kotlin_poc/src/main/kotlin/ftl/config/AndroidConfig.kt
@@ -10,8 +10,8 @@ class AndroidConfig(
         val testApk: String = "",
         val autoGoogleLogin: Boolean = true,
         val useOrchestrator: Boolean = true,
-        val environmentVariables: Map<String, String> = mapOf(),
-        val directoriesToPull: List<String> = listOf(),
+        val environmentVariables: Map<String, String> = emptyMap(),
+        val directoriesToPull: List<String> = emptyList(),
 
         rootGcsBucket: String,
         disablePerformanceMetrics: Boolean = true,
@@ -20,11 +20,12 @@ class AndroidConfig(
         testShards: Int = 1,
         testRuns: Int = 1,
         waitForResults: Boolean = true,
-        testMethods: List<String> = listOf(),
+        testMethods: List<String> = emptyList(),
+        testMethodsAlwaysRun: List<String> = emptyList(),
         limitBreak: Boolean = false,
         projectId: String = YamlConfig.getDefaultProjectId(),
         devices: List<Device> = listOf(Device("NexusLowRes", "23")),
-        testShardChunks: Set<Set<String>> = emptySet()
+        testShardChunks: List<List<String>> = emptyList()
 ) : YamlConfig(
         rootGcsBucket,
         disablePerformanceMetrics,
@@ -34,6 +35,7 @@ class AndroidConfig(
         testRuns,
         waitForResults,
         testMethods,
+        testMethodsAlwaysRun,
         limitBreak,
         projectId,
         devices,

--- a/cloud_testing/kotlin_poc/src/main/kotlin/ftl/config/IosConfig.kt
+++ b/cloud_testing/kotlin_poc/src/main/kotlin/ftl/config/IosConfig.kt
@@ -15,11 +15,12 @@ class IosConfig(
         testShards: Int = 1,
         testRuns: Int = 1,
         waitForResults: Boolean = true,
-        testMethods: List<String> = listOf(),
+        testMethods: List<String> = emptyList(),
+        testMethodsAlwaysRun: List<String> = emptyList(),
         limitBreak: Boolean = false,
         projectId: String = YamlConfig.getDefaultProjectId(),
         devices: List<Device> = listOf(Device("iphone8", "11.2")),
-        testShardChunks: Set<Set<String>> = emptySet()
+        testShardChunks: List<List<String>> = emptyList()
 ) : YamlConfig(
         rootGcsBucket,
         disablePerformanceMetrics,
@@ -29,6 +30,7 @@ class IosConfig(
         testRuns,
         waitForResults,
         testMethods,
+        testMethodsAlwaysRun,
         limitBreak,
         projectId,
         devices,

--- a/cloud_testing/kotlin_poc/src/main/kotlin/ftl/ios/Xctestrun.kt
+++ b/cloud_testing/kotlin_poc/src/main/kotlin/ftl/ios/Xctestrun.kt
@@ -38,7 +38,7 @@ object Xctestrun {
     private const val onlyTestIdentifiers = "OnlyTestIdentifiers"
 
     // Rewrites tests so that only the listed tests execute
-    private fun setOnlyTestIdentifiers(testDictionary: NSDictionary, tests: Set<String>) {
+    private fun setOnlyTestIdentifiers(testDictionary: NSDictionary, tests: Collection<String>) {
         val nsArray = NSArray(tests.size)
         tests.forEachIndexed { index, test -> nsArray.setValue(index, test) }
 
@@ -92,7 +92,7 @@ object Xctestrun {
         return NSObject.fromJavaObject(this.toJavaObject()) as NSDictionary
     }
 
-    fun rewrite(root: NSDictionary, methods: Set<String>): ByteArray {
+    fun rewrite(root: NSDictionary, methods: Collection<String>): ByteArray {
         val rootClone = root.deepClone()
         for (testTarget in rootClone.allKeys()) {
             val testDictionary = (rootClone[testTarget] as NSDictionary)

--- a/cloud_testing/kotlin_poc/src/test/kotlin/ftl/config/IosConfigTest.kt
+++ b/cloud_testing/kotlin_poc/src/test/kotlin/ftl/config/IosConfigTest.kt
@@ -77,11 +77,11 @@ class IosConfigTest {
 
         val chunk1 = arrayListOf("EarlGreyExampleMixedTests/testGrantCameraPermission",
                 "EarlGreyExampleMixedTests/testGrantMicrophonePermission",
-                "EarlGreyExampleMixedTests/testBasicSelection1",
-                "EarlGreyExampleMixedTests/testBasicSelection2")
+                "EarlGreyExampleMixedTests/testBasicSelection3",
+                "EarlGreyExampleMixedTests/testBasicSelection4")
 
         assertThat(config.testShardChunks.size).isEqualTo(2)
         assertThat(config.testShardChunks[0]).isEqualTo(chunk0)
-        assertThat(config.testShardChunks[0]).isEqualTo(chunk1)
+        assertThat(config.testShardChunks[1]).isEqualTo(chunk1)
     }
 }

--- a/cloud_testing/kotlin_poc/src/test/kotlin/ftl/config/IosConfigTest.kt
+++ b/cloud_testing/kotlin_poc/src/test/kotlin/ftl/config/IosConfigTest.kt
@@ -1,5 +1,6 @@
 package ftl.config
 
+import com.google.common.truth.Truth.assertThat
 import ftl.test.util.FlankTestRunner
 import ftl.test.util.TestHelper.assert
 import ftl.test.util.TestHelper.getPath
@@ -26,6 +27,7 @@ class IosConfigTest {
     val systemOutRule = SystemOutRule().muteForSuccessfulTests()!!
 
     private val yamlFile = getPath("src/test/kotlin/ftl/fixtures/flank.ios.yml")
+    private val yamlFile2 = getPath("src/test/kotlin/ftl/fixtures/flank2.ios.yml")
     private val xctestrunZip = getPath("src/test/kotlin/ftl/fixtures/tmp/EarlGreyExample.zip")
     private val xctestrunFile = getPath("src/test/kotlin/ftl/fixtures/tmp/EarlGreyExampleMixedTests_iphoneos11.2-arm64.xctestrun")
     private val testName = "EarlGreyExampleMixedTests/testBasicSelection"
@@ -62,5 +64,24 @@ class IosConfigTest {
         assert(iosConfig.contains("useOrchestrator"), false)
         assert(iosConfig.contains("environmentVariables"), false)
         assert(iosConfig.contains("directoriesToPull"), false)
+    }
+
+    @Test
+    fun testMethodsAlwaysRun() {
+        val config = IosConfig.load(yamlFile2)
+
+        val chunk0 = arrayListOf("EarlGreyExampleMixedTests/testGrantCameraPermission",
+                "EarlGreyExampleMixedTests/testGrantMicrophonePermission",
+                "EarlGreyExampleMixedTests/testBasicSelection1",
+                "EarlGreyExampleMixedTests/testBasicSelection2")
+
+        val chunk1 = arrayListOf("EarlGreyExampleMixedTests/testGrantCameraPermission",
+                "EarlGreyExampleMixedTests/testGrantMicrophonePermission",
+                "EarlGreyExampleMixedTests/testBasicSelection1",
+                "EarlGreyExampleMixedTests/testBasicSelection2")
+
+        assertThat(config.testShardChunks.size).isEqualTo(2)
+        assertThat(config.testShardChunks[0]).isEqualTo(chunk0)
+        assertThat(config.testShardChunks[0]).isEqualTo(chunk1)
     }
 }

--- a/cloud_testing/kotlin_poc/src/test/kotlin/ftl/fixtures/flank2.ios.yml
+++ b/cloud_testing/kotlin_poc/src/test/kotlin/ftl/fixtures/flank2.ios.yml
@@ -1,0 +1,25 @@
+xctestrunZip: ./src/test/kotlin/ftl/fixtures/tmp/EarlGreyExample.zip
+xctestrunFile: ./src/test/kotlin/ftl/fixtures/tmp/EarlGreyExampleMixedTests_iphoneos11.2-arm64.xctestrun
+rootGcsBucket: tmp_bucket_2
+disablePerformanceMetrics: true
+disableVideoRecording: false
+testTimeoutMinutes: 60
+testShards: 2
+testRuns: 1
+limitBreak: false
+waitForResults: true
+testMethods:
+  - EarlGreyExampleMixedTests/testGrantCameraPermission
+  - EarlGreyExampleMixedTests/testGrantMicrophonePermission
+  - EarlGreyExampleMixedTests/testBasicSelection1
+  - EarlGreyExampleMixedTests/testBasicSelection2
+  - EarlGreyExampleMixedTests/testBasicSelection3
+  - EarlGreyExampleMixedTests/testBasicSelection4
+testMethodsAlwaysRun:
+  - EarlGreyExampleMixedTests/testGrantCameraPermission
+  - EarlGreyExampleMixedTests/testGrantMicrophonePermission
+devices:
+  - model: iphone8
+    version: 11.2
+    orientation: portrait
+    locale: en_US

--- a/cloud_testing/kotlin_poc/src/test/kotlin/ftl/test/util/LocalGcs.kt
+++ b/cloud_testing/kotlin_poc/src/test/kotlin/ftl/test/util/LocalGcs.kt
@@ -3,7 +3,10 @@ package ftl.test.util
 import com.google.cloud.storage.BlobInfo
 import ftl.gc.GcStorage
 import org.junit.Assert
+import java.io.File
 import java.io.FileInputStream
+import java.nio.file.Files
+import java.nio.file.Paths
 
 object LocalGcs {
     private const val APP_APK = "app-debug.apk"
@@ -18,9 +21,9 @@ object LocalGcs {
     private const val TEST_BLOB_PATH = TEST_APK
 
     fun setupApks() {
-        val testApkInputStream = FileInputStream(TEST_APK_PATH)
+        val testApkBytes = Files.readAllBytes(Paths.get(TEST_APK_PATH))
         val testApkBlobInfo = BlobInfo.newBuilder(TEST_BUCKET, TEST_BLOB_PATH).build()
-        GcStorage.storage.create(testApkBlobInfo, testApkInputStream)
+        GcStorage.storage.create(testApkBlobInfo, testApkBytes)
 
         Assert.assertTrue(
                 GcStorage.storage.list(TEST_BUCKET).values

--- a/cloud_testing/kotlin_poc/src/test/kotlin/ftl/test/util/LocalGcs.kt
+++ b/cloud_testing/kotlin_poc/src/test/kotlin/ftl/test/util/LocalGcs.kt
@@ -31,9 +31,9 @@ object LocalGcs {
                         .any { TEST_BLOB_PATH == it }
         )
 
-        val appApkInputStream = FileInputStream(APP_APK_PATH)
+        val appApkBytes = Files.readAllBytes(Paths.get(APP_APK_PATH))
         val appApkBlobInfo = BlobInfo.newBuilder(TEST_BUCKET, APP_BLOB_PATH).build()
-        GcStorage.storage.create(appApkBlobInfo, appApkInputStream)
+        GcStorage.storage.create(appApkBlobInfo, appApkBytes)
 
         Assert.assertTrue(
                 GcStorage.storage.list(TEST_BUCKET).values


### PR DESCRIPTION
iOS requires permission. One way to solve this is by defining a set of grant permission tests that always run at the beginning of each shard. The tests will request and accept all required permissions (for example camera & microphone).