### PR TITLE
Make flank run with multiple test classes

### DIFF
--- a/test_runner/src/main/kotlin/ftl/filter/TestFilters.kt
+++ b/test_runner/src/main/kotlin/ftl/filter/TestFilters.kt
@@ -18,7 +18,7 @@ data class TestFilter(
 )
 
 private fun TestFilter.isTestMethod(): Boolean {
-    return describe.startsWith("withClassName") && describe.contains("#")
+    return describe.startsWith("withClassName")
 }
 
 /**

--- a/test_runner/src/test/kotlin/ftl/filter/TestFiltersTest.kt
+++ b/test_runner/src/test/kotlin/ftl/filter/TestFiltersTest.kt
@@ -52,6 +52,15 @@ class TestFiltersTest {
     }
 
     @Test
+    fun testFilteringByMultipleClasses() {
+        val testMethods = getTestMethodSet()
+        val filter = fromTestTargets(listOf("class d.e", "class h.i"))
+
+        val filtered = testMethods.asSequence().filter(filter.shouldRun).map { it.testName }.toList()
+        assertThat(filtered).isEqualTo(listOf("d.e#f", "h.i#j"))
+    }
+
+    @Test
     fun testFilteringByClassNameNegative() {
         val filter = fromTestTargets(listOf("notClass whatever.Foo"))
 


### PR DESCRIPTION
Right now you can run one test class by specifying

test-targets:
	- class Foo.Bar

But that doesn't work for multiple test classes.