### PR TITLE
Add flank cancel command to cancel unfinished matrices from the last run

### DIFF
--- a/test_runner/src/main/kotlin/ftl/Main.kt
+++ b/test_runner/src/main/kotlin/ftl/Main.kt
@@ -1,6 +1,7 @@
 package ftl
 
 import ftl.cli.FirebaseCommand
+import ftl.cli.firebase.CancelCommand
 import ftl.cli.firebase.test.AndroidCommand
 import ftl.cli.firebase.test.IosCommand
 import ftl.util.Utils.readTextResource
@@ -12,7 +13,8 @@ import picocli.CommandLine
     subcommands = [
         FirebaseCommand::class,
         IosCommand::class,
-        AndroidCommand::class
+        AndroidCommand::class,
+        CancelCommand::class
     ]
 )
 class Main : Runnable {

--- a/test_runner/src/main/kotlin/ftl/args/AndroidArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/AndroidArgs.kt
@@ -33,10 +33,10 @@ import java.nio.file.Path
 class AndroidArgs(
     gcloudYml: GcloudYml,
     androidGcloudYml: AndroidGcloudYml,
-    flankYml: FlankYml
+    flankYml: FlankYml,
+    override val data: String
 ) : IArgs {
     private val gcloud = gcloudYml.gcloud
-    override var filePath: Path? = null
     override val resultsBucket: String
     override val recordVideo = gcloud.recordVideo
     override val testTimeout = gcloud.timeout
@@ -159,11 +159,7 @@ ${listToString(testTargetsAlwaysRun)}
             mergeYmlMaps(GcloudYml, AndroidGcloudYml, FlankYml)
         }
 
-        fun load(data: Path): AndroidArgs {
-            val rtn = load(String(Files.readAllBytes(data)))
-            rtn.filePath = data
-            return rtn
-        }
+        fun load(data: Path): AndroidArgs = load(String(Files.readAllBytes(data)))
 
         fun load(data: String): AndroidArgs {
             val flankYml = yamlMapper.readValue(data, FlankYml::class.java)
@@ -173,7 +169,8 @@ ${listToString(testTargetsAlwaysRun)}
             return AndroidArgs(
                 gcloudYml,
                 androidGcloudYml,
-                flankYml
+                flankYml,
+                data
             )
         }
     }

--- a/test_runner/src/main/kotlin/ftl/args/AndroidArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/AndroidArgs.kt
@@ -36,6 +36,7 @@ class AndroidArgs(
     flankYml: FlankYml
 ) : IArgs {
     private val gcloud = gcloudYml.gcloud
+    override var filePath: Path? = null
     override val resultsBucket: String
     override val recordVideo = gcloud.recordVideo
     override val testTimeout = gcloud.timeout
@@ -158,7 +159,11 @@ ${listToString(testTargetsAlwaysRun)}
             mergeYmlMaps(GcloudYml, AndroidGcloudYml, FlankYml)
         }
 
-        fun load(data: Path): AndroidArgs = load(String(Files.readAllBytes(data)))
+        fun load(data: Path): AndroidArgs {
+            val rtn = load(String(Files.readAllBytes(data)))
+            rtn.filePath = data
+            return rtn
+        }
 
         fun load(data: String): AndroidArgs {
             val flankYml = yamlMapper.readValue(data, FlankYml::class.java)

--- a/test_runner/src/main/kotlin/ftl/args/IArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IArgs.kt
@@ -1,6 +1,10 @@
 package ftl.args
 
+import java.nio.file.Path
+
 interface IArgs {
+    var filePath: Path?
+
     // GcloudYml
     val resultsBucket: String
     val recordVideo: Boolean

--- a/test_runner/src/main/kotlin/ftl/args/IArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IArgs.kt
@@ -1,9 +1,8 @@
 package ftl.args
 
-import java.nio.file.Path
-
 interface IArgs {
-    var filePath: Path?
+    // original YAML data
+    val data: String
 
     // GcloudYml
     val resultsBucket: String

--- a/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
@@ -23,10 +23,11 @@ class IosArgs(
     gcloudYml: GcloudYml,
     iosGcloudYml: IosGcloudYml,
     flankYml: FlankYml,
-    iosFlankYml: IosFlankYml
+    iosFlankYml: IosFlankYml,
+    override val data: String
 ) : IArgs {
+
     private val gcloud = gcloudYml.gcloud
-    override var filePath: Path? = null
     override val resultsBucket = gcloud.resultsBucket
     override val recordVideo = gcloud.recordVideo
     override val testTimeout = gcloud.timeout
@@ -123,11 +124,7 @@ ${listToString(testTargets)}
             mergeYmlMaps(GcloudYml, IosGcloudYml, FlankYml, IosFlankYml)
         }
 
-        fun load(data: Path): IosArgs {
-            val rtn = IosArgs.load(String(Files.readAllBytes(data)))
-            rtn.filePath = data
-            return rtn
-        }
+        fun load(data: Path): IosArgs = IosArgs.load(String(Files.readAllBytes(data)))
 
         fun load(data: String): IosArgs {
             val flankYml = yamlMapper.readValue(data, FlankYml::class.java)
@@ -139,7 +136,8 @@ ${listToString(testTargets)}
                 gcloudYml,
                 iosGcloudYml,
                 flankYml,
-                iosFlankYml
+                iosFlankYml,
+                data
             )
         }
     }

--- a/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
@@ -26,6 +26,7 @@ class IosArgs(
     iosFlankYml: IosFlankYml
 ) : IArgs {
     private val gcloud = gcloudYml.gcloud
+    override var filePath: Path? = null
     override val resultsBucket = gcloud.resultsBucket
     override val recordVideo = gcloud.recordVideo
     override val testTimeout = gcloud.timeout
@@ -122,7 +123,11 @@ ${listToString(testTargets)}
             mergeYmlMaps(GcloudYml, IosGcloudYml, FlankYml, IosFlankYml)
         }
 
-        fun load(data: Path): IosArgs = IosArgs.load(String(Files.readAllBytes(data)))
+        fun load(data: Path): IosArgs {
+            val rtn = IosArgs.load(String(Files.readAllBytes(data)))
+            rtn.filePath = data
+            return rtn
+        }
 
         fun load(data: String): IosArgs {
             val flankYml = yamlMapper.readValue(data, FlankYml::class.java)

--- a/test_runner/src/main/kotlin/ftl/cli/FirebaseCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/FirebaseCommand.kt
@@ -1,5 +1,6 @@
 package ftl.cli
 
+import ftl.cli.firebase.CancelCommand
 import ftl.cli.firebase.TestCommand
 import ftl.cli.firebase.test.ios.IosDoctorCommand
 import picocli.CommandLine
@@ -10,6 +11,7 @@ import picocli.CommandLine.Command
     synopsisHeading = "",
     subcommands = [
         TestCommand::class,
+        CancelCommand::class,
         IosDoctorCommand::class
     ]
 )

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/CancelCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/CancelCommand.kt
@@ -1,27 +1,24 @@
 package ftl.cli.firebase
 
 import ftl.run.TestRunner
-import kotlinx.coroutines.experimental.runBlocking
 import picocli.CommandLine
 
 @CommandLine.Command(
-        name = "cancel",
-        sortOptions = false,
-        headerHeading = "",
-        synopsisHeading = "%n",
-        descriptionHeading = "%n@|bold,underline Description:|@%n%n",
-        parameterListHeading = "%n@|bold,underline Parameters:|@%n",
-        optionListHeading = "%n@|bold,underline Options:|@%n",
-        header = ["Cancels the last Firebase Test Lab run"],
-        description = ["""Selects the most recent run in the results/ folder.
+    name = "cancel",
+    sortOptions = false,
+    headerHeading = "",
+    synopsisHeading = "%n",
+    descriptionHeading = "%n@|bold,underline Description:|@%n%n",
+    parameterListHeading = "%n@|bold,underline Parameters:|@%n",
+    optionListHeading = "%n@|bold,underline Options:|@%n",
+    header = ["Cancels the last Firebase Test Lab run"],
+    description = ["""Selects the most recent run in the results/ folder.
 Reads in the matrix_ids.json file. Cancels any incomplete matrices.
 """]
 )
 class CancelCommand : Runnable {
     override fun run() {
-        runBlocking {
-            TestRunner.cancelLastRun()
-        }
+        TestRunner.cancelLastRun()
     }
 
     @CommandLine.Option(names = ["-h", "--help"], usageHelp = true, description = ["Prints this help message"])

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/CancelCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/CancelCommand.kt
@@ -1,0 +1,29 @@
+package ftl.cli.firebase
+
+import ftl.run.TestRunner
+import kotlinx.coroutines.experimental.runBlocking
+import picocli.CommandLine
+
+@CommandLine.Command(
+        name = "cancel",
+        sortOptions = false,
+        headerHeading = "",
+        synopsisHeading = "%n",
+        descriptionHeading = "%n@|bold,underline Description:|@%n%n",
+        parameterListHeading = "%n@|bold,underline Parameters:|@%n",
+        optionListHeading = "%n@|bold,underline Options:|@%n",
+        header = ["Cancels the last Firebase Test Lab run"],
+        description = ["""Selects the most recent run in the results/ folder.
+Reads in the matrix_ids.json file. Cancels any incomplete matrices.
+"""]
+)
+class CancelCommand : Runnable {
+    override fun run() {
+        runBlocking {
+            TestRunner.cancelLastRun()
+        }
+    }
+
+    @CommandLine.Option(names = ["-h", "--help"], usageHelp = true, description = ["Prints this help message"])
+    var usageHelpRequested: Boolean = false
+}

--- a/test_runner/src/main/kotlin/ftl/config/FtlConstants.kt
+++ b/test_runner/src/main/kotlin/ftl/config/FtlConstants.kt
@@ -7,6 +7,9 @@ import com.google.api.client.googleapis.util.Utils
 import com.google.api.client.http.HttpRequestInitializer
 import com.google.api.client.http.javanet.NetHttpTransport
 import com.google.api.client.json.JsonFactory
+import ftl.args.AndroidArgs
+import ftl.args.IArgs
+import ftl.args.IosArgs
 import ftl.http.TimeoutHttpRequestInitializer
 
 object FtlConstants {
@@ -52,4 +55,12 @@ object FtlConstants {
     }
 
     const val localResultsDir = "results"
+
+    fun configFileForArgs(args: IArgs): String {
+        return when (args) {
+            is IosArgs -> defaultIosConfig
+            is AndroidArgs -> defaultAndroidConfig
+            else -> throw RuntimeException("Unknown config type")
+        }
+    }
 }

--- a/test_runner/src/main/kotlin/ftl/config/FtlConstants.kt
+++ b/test_runner/src/main/kotlin/ftl/config/FtlConstants.kt
@@ -56,7 +56,7 @@ object FtlConstants {
 
     const val localResultsDir = "results"
 
-    fun configFileForArgs(args: IArgs): String {
+    fun configFileName(args: IArgs): String {
         return when (args) {
             is IosArgs -> defaultIosConfig
             is AndroidArgs -> defaultAndroidConfig

--- a/test_runner/src/main/kotlin/ftl/run/GenericTestRunner.kt
+++ b/test_runner/src/main/kotlin/ftl/run/GenericTestRunner.kt
@@ -35,6 +35,8 @@ object GenericTestRunner {
         val matrixMap = MatrixMap(savedMatrices, runGcsPath)
         TestRunner.updateMatrixFile(matrixMap)
 
+        TestRunner.saveConfigFile(matrixMap.runPath, config)
+
         println(FtlConstants.indent + "${savedMatrices.size} matrix ids created in ${stopwatch.check()}")
         val gcsBucket = "https://console.developers.google.com/storage/browser/" +
             config.resultsBucket + "/" + matrixMap.runPath

--- a/test_runner/src/test/kotlin/ftl/args/AndroidArgsFileTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/AndroidArgsFileTest.kt
@@ -103,7 +103,8 @@ class AndroidArgsFileTest {
                 FlankYmlParams(
                     testShards = testShards
                 )
-            )
+            ),
+            ""
         )
     }
 
@@ -167,7 +168,8 @@ class AndroidArgsFileTest {
                     test = oldConfig.testApk
                 )
             ),
-            FlankYml()
+            FlankYml(),
+            ""
         )
 
         assert(config.resultsBucket, "tmp_bucket_2")

--- a/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
@@ -70,7 +70,8 @@ class IosArgsTest {
             GcloudYml(),
             IosGcloudYml(IosGcloudYmlParams(test = testPath, xctestrunFile = xctestrunFile, device = invalidDevice)),
             FlankYml(),
-            IosFlankYml()
+            IosFlankYml(),
+            ""
         )
     }
 
@@ -81,7 +82,8 @@ class IosArgsTest {
                 GcloudYml(),
                 IosGcloudYml(IosGcloudYmlParams(test = testPath, xctestrunFile = xctestrunFile, xcodeVersion = "99.9")),
                 FlankYml(),
-                IosFlankYml()
+                IosFlankYml(),
+            ""
         )
     }
 

--- a/test_runner/src/test/kotlin/ftl/cli/FirebaseCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/FirebaseCommandTest.kt
@@ -21,6 +21,7 @@ class FirebaseCommandTest {
             "firebase [COMMAND]\n" +
                 "Commands:\n" +
                 "  test\n" +
+                "  cancel  Cancels the last Firebase Test Lab run\n" +
                 "  doctor  Verifies flank firebase is setup correctly\n"
         )
     }

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/CancelCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/CancelCommandTest.kt
@@ -1,0 +1,57 @@
+package ftl.cli.firebase
+
+import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
+import ftl.test.util.FlankTestRunner
+import org.junit.Rule
+import org.junit.Test
+import org.junit.contrib.java.lang.system.SystemOutRule
+import org.junit.runner.RunWith
+import picocli.CommandLine
+
+@RunWith(FlankTestRunner::class)
+class IosCancelCommandTest {
+    @Rule
+    @JvmField
+    val systemOutRule: SystemOutRule = SystemOutRule().enableLog().muteForSuccessfulTests()
+
+    @Test
+    fun cancelCommandPrintsHelp() {
+        val command = CancelCommand()
+        assertThat(command.usageHelpRequested).isFalse()
+        CommandLine.run<Runnable>(command, System.out, "-h")
+
+        val output = systemOutRule.log
+        Truth.assertThat(output).startsWith(
+                "Cancels the last Firebase Test Lab run\n" +
+                        "\n" +
+                        "cancel [-h]\n" +
+                        "\n" +
+                        "Description:\n" +
+                        "\n" +
+                        "Selects the most recent run in the results/ folder.\n" +
+                        "Reads in the matrix_ids.json file. Cancels any incomplete matrices.\n" +
+                        "\n" +
+                        "\n" +
+                        "Options:\n" +
+                        "  -h, --help   Prints this help message\n"
+        )
+
+        assertThat(command.usageHelpRequested).isTrue()
+    }
+
+    @Test
+    fun cancelCommandRuns() {
+        CancelCommand().run()
+        val output = systemOutRule.log
+        Truth.assertThat(output).contains("No matrices to cancel")
+    }
+
+    @Test
+    fun cancelCommandOptions() {
+        val cmd = CancelCommand()
+        assertThat(cmd.usageHelpRequested).isFalse()
+        cmd.usageHelpRequested = true
+        assertThat(cmd.usageHelpRequested).isTrue()
+    }
+}

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/CancelCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/CancelCommandTest.kt
@@ -2,6 +2,7 @@ package ftl.cli.firebase
 
 import com.google.common.truth.Truth
 import com.google.common.truth.Truth.assertThat
+import ftl.cli.firebase.test.android.AndroidRunCommand
 import ftl.test.util.FlankTestRunner
 import org.junit.Rule
 import org.junit.Test
@@ -10,7 +11,7 @@ import org.junit.runner.RunWith
 import picocli.CommandLine
 
 @RunWith(FlankTestRunner::class)
-class IosCancelCommandTest {
+class CancelCommandTest {
     @Rule
     @JvmField
     val systemOutRule: SystemOutRule = SystemOutRule().enableLog().muteForSuccessfulTests()
@@ -42,6 +43,7 @@ class IosCancelCommandTest {
 
     @Test
     fun cancelCommandRuns() {
+        AndroidRunCommand().run()
         CancelCommand().run()
         val output = systemOutRule.log
         Truth.assertThat(output).contains("No matrices to cancel")


### PR DESCRIPTION
Fix #194 

`flank cancel`

The matrices from the last run are processed. Any matrix with state != FINISHED will be cancelled asynchronously. 