### PR TITLE
Fix Swift test throws & Add Xcode 10.1 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ gcloud:
 
   # test and xctestrun-file are the only required args
   test: ./src/test/kotlin/ftl/fixtures/tmp/EarlGreyExample.zip
-  xctestrun-file: ./src/test/kotlin/ftl/fixtures/tmp/EarlGreyExampleSwiftTests_iphoneos11.2-arm64.xctestrun
+  xctestrun-file: ./src/test/kotlin/ftl/fixtures/tmp/EarlGreyExampleSwiftTests_iphoneos12.1-arm64e.xctestrun
   xcode-version: 9.2
   device:
     - model: iphone8

--- a/test_runner/flank.ios.yml
+++ b/test_runner/flank.ios.yml
@@ -10,7 +10,7 @@ gcloud:
 
   # test and xctestrun-file are the only required args
   test: ./src/test/kotlin/ftl/fixtures/tmp/EarlGreyExample.zip
-  xctestrun-file: ./src/test/kotlin/ftl/fixtures/tmp/EarlGreyExampleSwiftTests_iphoneos11.2-arm64.xctestrun
+  xctestrun-file: ./src/test/kotlin/ftl/fixtures/tmp/EarlGreyExampleSwiftTests_iphoneos12.1-arm64e.xctestrun
   xcode-version: 9.2
   device:
     - model: iphone8

--- a/test_runner/src/main/kotlin/ftl/ios/Parse.kt
+++ b/test_runner/src/main/kotlin/ftl/ios/Parse.kt
@@ -73,7 +73,7 @@ object Parse {
         demangledOutput.lines().forEach { line ->
             // _T025EarlGreyExampleTestsSwift0abceD0C10testLayoutyyF ---> EarlGreyExampleTestsSwift.EarlGreyExampleSwiftTests.testLayout() -> ()
             // _T025EarlGreyExampleTestsSwift0abceD0C16testCustomActionyyF ---> EarlGreyExampleTestsSwift.EarlGreyExampleSwiftTests.testCustomAction() -> ()
-            val pattern = """.+\s--->\s.+\.(.+\.test.+)\(\)\s->\s\(\)""".toRegex()
+            val pattern = """.+\s--->\s.+\.(.+\.test.+)\(\)\s.*->\s\(\)""".toRegex()
             val matcher = pattern.find(line)
             if (matcher != null && matcher.groupValues.size == 2) {
                 results.add(methodName(matcher))

--- a/test_runner/src/main/kotlin/ftl/ios/Parse.kt
+++ b/test_runner/src/main/kotlin/ftl/ios/Parse.kt
@@ -73,8 +73,10 @@ object Parse {
         demangledOutput.lines().forEach { line ->
             // _T025EarlGreyExampleTestsSwift0abceD0C10testLayoutyyF ---> EarlGreyExampleTestsSwift.EarlGreyExampleSwiftTests.testLayout() -> ()
             // _T025EarlGreyExampleTestsSwift0abceD0C16testCustomActionyyF ---> EarlGreyExampleTestsSwift.EarlGreyExampleSwiftTests.testCustomAction() -> ()
+            // _$S25EarlGreyExampleTestsSwift0abceD0C14testThatThrowsyyKF ---> EarlGreyExampleTestsSwift.EarlGreyExampleSwiftTests.testThatThrows() throws -> ()
             val pattern = """.+\s--->\s.+\.(.+\.test.+)\(\)\s.*->\s\(\)""".toRegex()
             val matcher = pattern.find(line)
+
             if (matcher != null && matcher.groupValues.size == 2) {
                 results.add(methodName(matcher))
             }

--- a/test_runner/src/main/kotlin/ftl/ios/Xctestrun.kt
+++ b/test_runner/src/main/kotlin/ftl/ios/Xctestrun.kt
@@ -11,6 +11,7 @@ object Xctestrun {
 
     // Parses all tests for a given target
     private fun testsForTarget(testDictionary: NSDictionary, testTarget: String, testRoot: String): List<String> {
+        if (testTarget.contentEquals("__xctestrun_metadata__")) return emptyList()
         val productPaths = (testDictionary["DependentProductPaths"] as NSArray)
         for (product in productPaths.array) {
             val productString = product.toString()

--- a/test_runner/src/test/kotlin/ftl/args/IosArgsFileTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/IosArgsFileTest.kt
@@ -26,7 +26,7 @@ class IosArgsFileTest {
     private val yamlFile2 = getPath("src/test/kotlin/ftl/fixtures/flank2.ios.yml")
     private val xctestrunZip = getPath("src/test/kotlin/ftl/fixtures/tmp/EarlGreyExample.zip")
     private val xctestrunFile =
-        getPath("src/test/kotlin/ftl/fixtures/tmp/EarlGreyExampleMixedTests_iphoneos11.2-arm64.xctestrun")
+        getPath("src/test/kotlin/ftl/fixtures/tmp/EarlGreyExampleSwiftTests_iphoneos12.1-arm64e.xctestrun")
     private val testName = "EarlGreyExampleMixedTests/testBasicSelection"
     // NOTE: Change working dir to '%MODULE_WORKING_DIR%' in IntelliJ to match gradle for this test to pass.
     @Test

--- a/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
@@ -20,7 +20,7 @@ class IosArgsTest {
     private val empty = emptyList<String>()
     private val testPath = "./src/test/kotlin/ftl/fixtures/tmp/EarlGreyExample.zip"
     private val xctestrunFile =
-        "./src/test/kotlin/ftl/fixtures/tmp/EarlGreyExampleMixedTests_iphoneos11.2-arm64.xctestrun"
+        "./src/test/kotlin/ftl/fixtures/tmp/EarlGreyExampleSwiftTests_iphoneos12.1-arm64e.xctestrun"
     private val iosNonDefault = """
         gcloud:
           results-bucket: mockBucket
@@ -206,7 +206,7 @@ IosArgs
 
         with(iosArgs) {
             assert(testShards, -1)
-            assert(testShardChunks.size, 6)
+            assert(testShardChunks.size, 17)
             testShardChunks.forEach { chunk -> assert(chunk.size, 1) }
         }
     }

--- a/test_runner/src/test/kotlin/ftl/fixtures/flank.ios.gcs.yml
+++ b/test_runner/src/test/kotlin/ftl/fixtures/flank.ios.gcs.yml
@@ -2,7 +2,7 @@ gcloud:
   # only test is supported on gcs
   test: gs://tmp_bucket_2/EarlGreyExample.zip
   # testrun & the app itself must exist locally for analysis and sharding.
-  xctestrun-file: ./src/test/kotlin/ftl/fixtures/tmp/EarlGreyExampleMixedTests_iphoneos11.2-arm64.xctestrun
+  xctestrun-file: ./src/test/kotlin/ftl/fixtures/tmp/EarlGreyExampleSwiftTests_iphoneos12.1-arm64e.xctestrun
   results-history-name: android-gcs
   results-bucket: tmp_bucket_2
   record-video: true

--- a/test_runner/src/test/kotlin/ftl/fixtures/flank.ios.yml
+++ b/test_runner/src/test/kotlin/ftl/fixtures/flank.ios.yml
@@ -1,6 +1,6 @@
 gcloud:
   test: ./src/test/kotlin/ftl/fixtures/tmp/EarlGreyExample.zip
-  xctestrun-file: ./src/test/kotlin/ftl/fixtures/tmp/EarlGreyExampleMixedTests_iphoneos11.2-arm64.xctestrun
+  xctestrun-file: ./src/test/kotlin/ftl/fixtures/tmp/EarlGreyExampleSwiftTests_iphoneos12.1-arm64e.xctestrun
   results-bucket: tmp_bucket_2
   record-video: true
   timeout: 60m

--- a/test_runner/src/test/kotlin/ftl/fixtures/flank2.ios.yml
+++ b/test_runner/src/test/kotlin/ftl/fixtures/flank2.ios.yml
@@ -1,6 +1,6 @@
 gcloud:
   test: ./src/test/kotlin/ftl/fixtures/tmp/EarlGreyExample.zip
-  xctestrun-file: ./src/test/kotlin/ftl/fixtures/tmp/EarlGreyExampleMixedTests_iphoneos11.2-arm64.xctestrun
+  xctestrun-file: ./src/test/kotlin/ftl/fixtures/tmp/EarlGreyExampleSwiftTests_iphoneos12.1-arm64e.xctestrun
   results-bucket: tmp_bucket_2
   record-video: true
   timeout: 60m

--- a/test_runner/src/test/kotlin/ftl/ios/ParseTest.kt
+++ b/test_runner/src/test/kotlin/ftl/ios/ParseTest.kt
@@ -41,6 +41,7 @@ class ParseTest {
         "EarlGreyExampleSwiftTests/testLayout",
         "EarlGreyExampleSwiftTests/testSelectionOnMultipleElements",
         "EarlGreyExampleSwiftTests/testTableCellOutOfScreen",
+        "EarlGreyExampleSwiftTests/testThatThrows",
         "EarlGreyExampleSwiftTests/testWithCondition",
         "EarlGreyExampleSwiftTests/testWithCustomAssertion",
         "EarlGreyExampleSwiftTests/testWithCustomFailureHandler",
@@ -70,10 +71,10 @@ class ParseTest {
         val results = Parse.parseSwiftTests(swiftBinary).sorted()
 
         results.forEachIndexed { index, result ->
-            assertThat(swiftTests[index]).isEqualTo(result)
+            assertThat(result).isEqualTo(swiftTests[index])
         }
 
-        assertThat(swiftTests.size).isEqualTo(results.size)
+        assertThat(results.size).isEqualTo(swiftTests.size)
     }
 
     @Test(expected = RuntimeException::class)

--- a/test_runner/src/test/kotlin/ftl/ios/XctestrunTest.kt
+++ b/test_runner/src/test/kotlin/ftl/ios/XctestrunTest.kt
@@ -10,7 +10,7 @@ import org.junit.runner.RunWith
 @RunWith(FlankTestRunner::class)
 class XctestrunTest {
 
-    private val swiftXctestrun = "$fixturesPath/EarlGreyExampleSwiftTests_iphoneos11.2-arm64.xctestrun"
+    private val swiftXctestrun = "$fixturesPath/EarlGreyExampleSwiftTests_iphoneos12.1-arm64e.xctestrun"
     private val swiftTests = listOf(
         "EarlGreyExampleSwiftTests/testBasicSelection",
         "EarlGreyExampleSwiftTests/testBasicSelectionActionAssert",
@@ -22,6 +22,7 @@ class XctestrunTest {
         "EarlGreyExampleSwiftTests/testLayout",
         "EarlGreyExampleSwiftTests/testSelectionOnMultipleElements",
         "EarlGreyExampleSwiftTests/testTableCellOutOfScreen",
+        "EarlGreyExampleSwiftTests/testThatThrows",
         "EarlGreyExampleSwiftTests/testWithCondition",
         "EarlGreyExampleSwiftTests/testWithCustomAssertion",
         "EarlGreyExampleSwiftTests/testWithCustomFailureHandler",
@@ -33,7 +34,7 @@ class XctestrunTest {
     @Test
     fun parse() {
         val result = Xctestrun.parse(swiftXctestrun)
-        assertThat(arrayOf("EarlGreyExampleSwiftTests")).isEqualTo(result.allKeys())
+        assertThat(arrayOf("EarlGreyExampleSwiftTests", "__xctestrun_metadata__")).isEqualTo(result.allKeys())
         val dict = result["EarlGreyExampleSwiftTests"] as NSDictionary
         assertThat(dict.count()).isEqualTo(15)
         assertThat(dict.containsKey("OnlyTestIdentifiers")).isFalse()

--- a/test_runner/src/test/kotlin/ftl/test/util/LocalGcs.kt
+++ b/test_runner/src/test/kotlin/ftl/test/util/LocalGcs.kt
@@ -32,7 +32,7 @@ object LocalGcs {
         val appApk = "../test_app/apks/app-debug.apk"
         val testApk = "../test_app/apks/app-debug-androidTest.apk"
         val ipaZip = "./src/test/kotlin/ftl/fixtures/tmp/EarlGreyExample.zip"
-        val xctestrun = "./src/test/kotlin/ftl/fixtures/tmp/EarlGreyExampleMixedTests_iphoneos11.2-arm64.xctestrun"
+        val xctestrun = "./src/test/kotlin/ftl/fixtures/tmp/EarlGreyExampleSwiftTests_iphoneos12.1-arm64e.xctestrun"
 
         listOf(appApk, testApk, ipaZip, xctestrun).forEach { file ->
             uploadToMockGcs(Paths.get(file))


### PR DESCRIPTION
- Updated the regular expression used for filter the tests.

- Fix #371 


