### PR TITLE
Add a parameter to shuffle the tests before sharding

### DIFF
--- a/test_runner/flank.ios.yml
+++ b/test_runner/flank.ios.yml
@@ -32,3 +32,9 @@ flank:
   # test targets - a list of tests to run. omit to run all tests.
   # test-targets:
   #   - b/testBasicSelection
+
+  # whether you want your tests to be shuffled before sharding.
+  # If you have heavy tests in the same class, default sharding will put them together.
+  # setting this to true will ensure that they are somewhat spread across all the shards.
+  # false by default
+  shuffleTests: false

--- a/test_runner/flank.yml
+++ b/test_runner/flank.yml
@@ -37,3 +37,9 @@ flank:
   # useful if you need to grant permissions or login before other tests run
   # test-targets-always-run:
     # - class com.example.app.ExampleUiTest#testPasses
+
+  # whether you want your tests to be shuffled before sharding.
+  # If you have heavy tests in the same class, default sharding will put them together.
+  # setting this to true will ensure that they are somewhat spread across all the shards.
+  # false by default
+  shuffleTests: false

--- a/test_runner/src/main/kotlin/ftl/args/AndroidArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/AndroidArgs.kt
@@ -70,13 +70,13 @@ class AndroidArgs(
             }
         }
 
-        val filteredTests = getTestMethods(testLocalApk)
+        val filteredTests = getTestMethods(testLocalApk, shuffled = flank.testsShuffled)
 
         calculateShards(
             filteredTests,
             testTargetsAlwaysRun,
             testShards
-            )
+        )
     }
 
     init {
@@ -97,7 +97,7 @@ class AndroidArgs(
         devices.forEach { device -> assertDeviceSupported(device) }
     }
 
-    private fun getTestMethods(testLocalApk: String): List<String> {
+    private fun getTestMethods(testLocalApk: String, shuffled: Boolean): List<String> {
         val allTestMethods = DexParser.findTestMethods(testLocalApk)
         require(allTestMethods.isNotEmpty()) { Utils.fatalError("Test APK has no tests") }
         val testFilter = TestFilters.fromTestTargets(testTargets)
@@ -106,7 +106,11 @@ class AndroidArgs(
             .filter(testFilter.shouldRun)
             .map(TestMethod::testName)
             .map { "class $it" }
-            .toList()
+            .toList().also {
+                if (shuffled) {
+                    it.shuffled()
+                }
+            }
         require(useMock || filteredTests.isNotEmpty()) { Utils.fatalError("All tests filtered out") }
         return filteredTests
     }

--- a/test_runner/src/main/kotlin/ftl/args/AndroidArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/AndroidArgs.kt
@@ -70,7 +70,7 @@ class AndroidArgs(
             }
         }
 
-        val filteredTests = getTestMethods(testLocalApk, shuffled = flank.testsShuffled)
+        val filteredTests = getTestMethods(testLocalApk, shuffled = flank.shuffleTests)
 
         calculateShards(
             filteredTests,

--- a/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
@@ -58,7 +58,7 @@ class IosArgs(
         } else {
             testTargets
         }.also {
-            if (flank.testsShuffled) {
+            if (flank.shuffleTests) {
                 it.shuffled()
             }
         }

--- a/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
@@ -57,13 +57,17 @@ class IosArgs(
             validTestMethods
         } else {
             testTargets
+        }.also {
+            if (flank.testsShuffled) {
+                it.shuffled()
+            }
         }
 
         ArgsHelper.calculateShards(
             testMethodsToShard = testsToShard,
             testMethodsAlwaysRun = testTargetsAlwaysRun,
             testShards = testShards
-            )
+        )
     }
 
     init {

--- a/test_runner/src/main/kotlin/ftl/args/yml/FlankYml.kt
+++ b/test_runner/src/main/kotlin/ftl/args/yml/FlankYml.kt
@@ -9,13 +9,13 @@ import ftl.util.Utils.fatalError
 class FlankYmlParams(
     val testShards: Int = 1,
     val repeatTests: Int = 1,
-    val testsShuffled : Boolean = false,
+    val shuffleTests : Boolean = false,
 
     @field:JsonProperty("test-targets-always-run")
     val testTargetsAlwaysRun: List<String> = emptyList()
 ) {
     companion object : IYmlKeys {
-        override val keys = listOf("testShards", "repeatTests", "test-targets-always-run", "testsShuffled")
+        override val keys = listOf("testShards", "repeatTests", "test-targets-always-run", "shuffleTests")
     }
 
     init {

--- a/test_runner/src/main/kotlin/ftl/args/yml/FlankYml.kt
+++ b/test_runner/src/main/kotlin/ftl/args/yml/FlankYml.kt
@@ -9,7 +9,7 @@ import ftl.util.Utils.fatalError
 class FlankYmlParams(
     val testShards: Int = 1,
     val repeatTests: Int = 1,
-    val shuffleTests : Boolean = false,
+    val shuffleTests: Boolean = false,
 
     @field:JsonProperty("test-targets-always-run")
     val testTargetsAlwaysRun: List<String> = emptyList()

--- a/test_runner/src/main/kotlin/ftl/args/yml/FlankYml.kt
+++ b/test_runner/src/main/kotlin/ftl/args/yml/FlankYml.kt
@@ -9,12 +9,13 @@ import ftl.util.Utils.fatalError
 class FlankYmlParams(
     val testShards: Int = 1,
     val repeatTests: Int = 1,
+    val testsShuffled : Boolean = false,
 
     @field:JsonProperty("test-targets-always-run")
     val testTargetsAlwaysRun: List<String> = emptyList()
 ) {
     companion object : IYmlKeys {
-        override val keys = listOf("testShards", "repeatTests", "test-targets-always-run")
+        override val keys = listOf("testShards", "repeatTests", "test-targets-always-run", "testsShuffled")
     }
 
     init {


### PR DESCRIPTION
A use case we have is we have a lot of tests which have arbitrary sleeps ( probably something we should work to eliminate ). These take a longer time to complete than our other tests. As it so happens, all of these are in the same class. So when sharding, most of these end up in the same shard.

Shuffling will ensure some variance in where these tests end up, and will ensure faster CI.