### PR TITLE
Improve exit code reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ Stability testing
 HTML report
 JUnit XML report
 
+### Exit Codes
+
+Exit code | Description
+ --       |         -- |
+0         | All tests passed
+1         | At least one test failed or inconclusive and all matrices finished.
+2         | At least one matrix not finished, usually a FTL error.
+
 ### iOS example
 
 Run `test_runner/flank.ios.yml` with flank to verify iOS execution is working.

--- a/test_runner/src/main/kotlin/ftl/json/MatrixMap.kt
+++ b/test_runner/src/main/kotlin/ftl/json/MatrixMap.kt
@@ -1,6 +1,6 @@
 package ftl.json
 
-import ftl.util.Outcome
+import ftl.util.MatrixState
 
 class MatrixMap(
     val map: MutableMap<String, SavedMatrix>,
@@ -13,9 +13,33 @@ class MatrixMap(
         var successful = true
 
         savedMatrices.forEach { matrix ->
-            if (matrix.outcome != Outcome.success) successful = false
+            if (matrix.failed()) successful = false
         }
 
         return successful
+    }
+
+    /**
+     * There are two sources of information for detecting the exit code
+     * 1) Matrix state via test API (MatrixState.kt)
+     * 2) Step outcome via tool results API (Outcome.kt)
+     *
+     * A test that fails will have a matrix state of finished with an outcome of failure.
+     * A matrix state of error means FTL had an infrastructure failure
+     * A step outcome of failure means at least one test failed.
+     *
+     * exit code 0 - all tests passed
+     * exit code 1 - at least one test failed/inconclusive & all matrices finished
+     * exit code 2 - at least one matrix not finished (usually FTL error)
+     */
+    fun exitCode(): Int {
+        var exitCode = 0
+
+        map.values.forEach { matrix ->
+            if (matrix.state != MatrixState.FINISHED) return 2
+            if (matrix.failed()) exitCode = 1
+        }
+
+        return exitCode
     }
 }

--- a/test_runner/src/main/kotlin/ftl/json/SavedMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/json/SavedMatrix.kt
@@ -1,15 +1,17 @@
 package ftl.json
 
+import com.google.api.client.json.GenericJson
 import com.google.api.services.testing.model.TestMatrix
 import com.google.api.services.toolresults.model.Outcome
 import ftl.android.AndroidCatalog
 import ftl.gc.GcToolResults
 import ftl.util.Billing
 import ftl.util.MatrixState.FINISHED
-import ftl.util.Outcome.failure
-import ftl.util.Outcome.inconclusive
-import ftl.util.Outcome.skipped
-import ftl.util.Outcome.success
+import ftl.util.StepOutcome.failure
+import ftl.util.StepOutcome.inconclusive
+import ftl.util.StepOutcome.skipped
+import ftl.util.StepOutcome.success
+import ftl.util.StepOutcome.unset
 import ftl.util.webLink
 
 // execution gcs paths aren't API accessible.
@@ -28,11 +30,19 @@ class SavedMatrix(matrix: TestMatrix) {
         private set
     var outcome: String = ""
         private set
-    var outcomeAdditionalDetails: String = ""
+    var outcomeDetails: String = ""
         private set
 
     init {
         if (this.state == FINISHED) finished(matrix)
+    }
+
+    fun failed(): Boolean {
+        return when (outcome) {
+            failure -> true
+            inconclusive -> true
+            else -> false
+        }
     }
 
     /** return true if the content changed **/
@@ -55,16 +65,21 @@ class SavedMatrix(matrix: TestMatrix) {
     }
 
     private fun finished(matrix: TestMatrix) {
-        if (matrix.state != FINISHED) throw RuntimeException("Incorrect matrix state. Expected:'finished', Actual:" + matrix.state)
+        if (matrix.state != FINISHED) {
+            throw RuntimeException("Matrix ${matrix.testMatrixId} ${matrix.state} != $FINISHED")
+        }
         billableVirtualMinutes = 0
         billablePhysicalMinutes = 0
         outcome = success
         if (matrix.testExecutions == null) return
+
         matrix.testExecutions.forEach {
             val step = GcToolResults.getResults(it.toolResultsStep)
             updateOutcome(step.outcome)
+
             if (step.testExecutionStep == null) return
             val billableMinutes = Billing.billableMinutes(step.testExecutionStep.testTiming.testProcessDuration.seconds)
+
             if (AndroidCatalog.isVirtualDevice(it.environment?.androidDevice)) {
                 billableVirtualMinutes += billableMinutes
             } else {
@@ -74,17 +89,25 @@ class SavedMatrix(matrix: TestMatrix) {
     }
 
     private fun updateOutcome(stepOutcome: Outcome) {
-        // 'failure' outcome gets the highest precedence,
-        // so update outcome only if the current state is not failure.
-        if (outcome != failure) {
-            outcome = stepOutcome.summary
-            when (outcome) {
-                failure -> outcomeAdditionalDetails = stepOutcome.failureDetail?.keys?.joinToString(",") ?: ""
-                success -> outcomeAdditionalDetails = stepOutcome.successDetail?.keys?.joinToString(",") ?: ""
-                inconclusive -> outcomeAdditionalDetails = stepOutcome.inconclusiveDetail?.keys?.joinToString(",") ?: ""
-                skipped -> outcomeAdditionalDetails = stepOutcome.skippedDetail?.keys?.joinToString(",") ?: ""
-            }
+        // the matrix outcome is failure if any step fails
+        // if the matrix outcome is already set to failure then we can ignore the other step outcomes.
+        // inconclusive is treated as a failure
+        if (outcome == failure || outcome == inconclusive) return
+
+        outcome = stepOutcome.summary
+
+        outcomeDetails = when (outcome) {
+            failure -> stepOutcome.failureDetail.keysToString()
+            success -> stepOutcome.successDetail.keysToString()
+            inconclusive -> stepOutcome.inconclusiveDetail.keysToString()
+            skipped -> stepOutcome.skippedDetail.keysToString()
+            unset -> "unset"
+            else -> "unknown"
         }
+    }
+
+    private fun GenericJson?.keysToString(): String {
+        return this?.keys?.joinToString(",") ?: ""
     }
 
     val gcsPathWithoutRootBucket get() = gcsPath.substringAfter('/')

--- a/test_runner/src/main/kotlin/ftl/reports/MatrixResultsReport.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/MatrixResultsReport.kt
@@ -27,12 +27,12 @@ object MatrixResultsReport : IReport {
     private fun generate(matrices: MatrixMap): String {
         var total = 0
         var success = 0
-        val failureWebLinks = mutableListOf<String>()
+        val failureDetails = mutableListOf<Triple<String, String, String>>()
         matrices.map.values.forEach { matrix ->
             total += 1
             when (matrix.outcome) {
                 Outcome.success -> success += 1
-                else -> failureWebLinks.add(matrix.webLink)
+                else -> failureDetails.add(Triple(matrix.matrixId, matrix.webLink, matrix.outcomeAdditionalDetails))
             }
         }
         val failed = total - success
@@ -48,9 +48,15 @@ object MatrixResultsReport : IReport {
             if (failed > 0) {
                 writer.println("$indent$failed matrices failed")
                 writer.println()
-                writer.println("${indent}Failed matrix links:")
-                failureWebLinks.forEach { writer.println(indent + it) }
-                println()
+                failureDetails.forEach {
+                    writer.println("${indent}Failed matrix:")
+                    writer.println("${indent}${indent}Matrix Id: " + it.first)
+                    if (!it.third.isNullOrEmpty()) {
+                        writer.println("${indent}${indent}Reason: " + it.third)
+                    }
+                    writer.println("${indent}${indent}Web Link: " + it.second)
+                    writer.println()
+                }
             }
 
             return writer.toString()

--- a/test_runner/src/main/kotlin/ftl/reports/MatrixResultsReport.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/MatrixResultsReport.kt
@@ -2,9 +2,9 @@ package ftl.reports
 
 import ftl.config.FtlConstants.indent
 import ftl.json.MatrixMap
+import ftl.json.SavedMatrix
 import ftl.reports.util.IReport
 import ftl.reports.xml.model.JUnitTestResult
-import ftl.util.Outcome
 import ftl.util.Utils.println
 import ftl.util.Utils.write
 import java.io.StringWriter
@@ -27,12 +27,14 @@ object MatrixResultsReport : IReport {
     private fun generate(matrices: MatrixMap): String {
         var total = 0
         var success = 0
-        val failureDetails = mutableListOf<Triple<String, String, String>>()
+        val failedMatrices = mutableListOf<SavedMatrix>()
         matrices.map.values.forEach { matrix ->
             total += 1
-            when (matrix.outcome) {
-                Outcome.success -> success += 1
-                else -> failureDetails.add(Triple(matrix.matrixId, matrix.webLink, matrix.outcomeAdditionalDetails))
+
+            if (matrix.failed()) {
+                failedMatrices.add(matrix)
+            } else {
+                success += 1
             }
         }
         val failed = total - success
@@ -48,13 +50,9 @@ object MatrixResultsReport : IReport {
             if (failed > 0) {
                 writer.println("$indent$failed matrices failed")
                 writer.println()
-                failureDetails.forEach {
-                    writer.println("${indent}Failed matrix:")
-                    writer.println("${indent}${indent}Matrix Id: " + it.first)
-                    if (!it.third.isNullOrEmpty()) {
-                        writer.println("${indent}${indent}Reason: " + it.third)
-                    }
-                    writer.println("${indent}${indent}Web Link: " + it.second)
+                failedMatrices.forEach {
+                    writer.println("$indent${it.matrixId} ${it.outcomeDetails}")
+                    writer.println("$indent${it.webLink}")
                     writer.println()
                 }
             }

--- a/test_runner/src/main/kotlin/ftl/reports/util/ReportManager.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/util/ReportManager.kt
@@ -63,7 +63,7 @@ object ReportManager {
     }
 
     /** Returns true if there were no test failures */
-    fun generate(matrices: MatrixMap, config: IArgs): Boolean {
+    fun generate(matrices: MatrixMap, config: IArgs): Int {
         val iosXml = config is IosArgs
         val testSuite = if (iosXml) {
             processXml(matrices, ::parseIosXml)
@@ -87,6 +87,6 @@ object ReportManager {
             ).map { it.run(matrices, testSuite) }
         }
 
-        return testSuccessful
+        return matrices.exitCode()
     }
 }

--- a/test_runner/src/main/kotlin/ftl/run/TestRunner.kt
+++ b/test_runner/src/main/kotlin/ftl/run/TestRunner.kt
@@ -336,8 +336,9 @@ object TestRunner {
         fetchArtifacts(matrixMap)
 
         // Must generate reports *after* fetching xml artifacts since reports require xml
-        val testsSuccessful = ReportManager.generate(matrixMap, config)
-        if (!testsSuccessful) System.exit(1)
+        ReportManager.generate(matrixMap, config)
+        var eixtCode = getExitCode(matrixMap)
+        System.exit(eixtCode)
     }
 
     // used to cancel and update results from an async run
@@ -356,8 +357,9 @@ object TestRunner {
             pollMatrices(matrixMap, config)
             fetchArtifacts(matrixMap)
 
-            val testsSuccessful = ReportManager.generate(matrixMap, config)
-            if (!testsSuccessful) System.exit(1)
+            ReportManager.generate(matrixMap, config)
+            var exitCode = getExitCode(matrixMap)
+            System.exit(exitCode)
         }
     }
 }

--- a/test_runner/src/main/kotlin/ftl/run/TestRunner.kt
+++ b/test_runner/src/main/kotlin/ftl/run/TestRunner.kt
@@ -336,9 +336,8 @@ object TestRunner {
         fetchArtifacts(matrixMap)
 
         // Must generate reports *after* fetching xml artifacts since reports require xml
-        ReportManager.generate(matrixMap, config)
-        var eixtCode = getExitCode(matrixMap)
-        System.exit(eixtCode)
+        val exitCode = ReportManager.generate(matrixMap, config)
+        System.exit(exitCode)
     }
 
     // used to cancel and update results from an async run
@@ -357,8 +356,7 @@ object TestRunner {
             pollMatrices(matrixMap, config)
             fetchArtifacts(matrixMap)
 
-            ReportManager.generate(matrixMap, config)
-            var exitCode = getExitCode(matrixMap)
+            val exitCode = ReportManager.generate(matrixMap, config)
             System.exit(exitCode)
         }
     }

--- a/test_runner/src/main/kotlin/ftl/util/MatrixState.kt
+++ b/test_runner/src/main/kotlin/ftl/util/MatrixState.kt
@@ -8,6 +8,13 @@ object MatrixState {
     const val PENDING = "PENDING"
     const val RUNNING = "RUNNING"
     const val FINISHED = "FINISHED"
+    const val TEST_STATE_UNSPECIFIED = "TEST_STATE_UNSPECIFIED"
+    const val ERROR = "ERROR"
+    const val UNSUPPORTED_ENVIRONMENT = "UNSUPPORTED_ENVIRONMENT"
+    const val INCOMPATIBLE_ENVIRONMENT = "INCOMPATIBLE_ENVIRONMENT"
+    const val INCOMPATIBLE_ARCHITECTURE = "INCOMPATIBLE_ARCHITECTURE"
+    const val CANCELLED = "CANCELLED"
+    const val INVALID = "INVALID"
 
     fun inProgress(state: String): Boolean {
         return when (state) {

--- a/test_runner/src/main/kotlin/ftl/util/Outcome.kt
+++ b/test_runner/src/main/kotlin/ftl/util/Outcome.kt
@@ -1,6 +1,10 @@
 package ftl.util
 
 object Outcome {
+    // https://github.com/bootstraponline/gcloud_cli/blob/master/google-cloud-sdk/lib/googlecloudsdk/third_party/apis/toolresults_v1beta3.json#L755
     const val success = "success"
     const val failure = "failure"
+    const val inconclusive = "inconclusive"
+    const val skipped = "skipped"
+    const val unset = "unset"
 }

--- a/test_runner/src/main/kotlin/ftl/util/StepOutcome.kt
+++ b/test_runner/src/main/kotlin/ftl/util/StepOutcome.kt
@@ -1,6 +1,7 @@
 package ftl.util
 
-object Outcome {
+// ToolResults API step outcome values
+object StepOutcome {
     // https://github.com/bootstraponline/gcloud_cli/blob/master/google-cloud-sdk/lib/googlecloudsdk/third_party/apis/toolresults_v1beta3.json#L755
     const val success = "success"
     const val failure = "failure"

--- a/test_runner/src/main/kotlin/ftl/util/Utils.kt
+++ b/test_runner/src/main/kotlin/ftl/util/Utils.kt
@@ -1,7 +1,6 @@
 package ftl.util
 
 import ftl.config.FtlConstants
-import ftl.json.MatrixMap
 import java.io.InputStream
 import java.io.StringWriter
 import java.nio.file.Files
@@ -127,36 +126,5 @@ object Utils {
         val bytes = getResource("binaries/$name").use { it.readBytes() }
         Files.write(destinationPath, bytes)
         destinationFile.setExecutable(true)
-    }
-
-    /**
-     * exit code 0 - all tests passed
-     * exit code 1 - at least test failed & no FTL errors
-     * exit code 2 - at least one infrastructure failure or other FTL error
-     */
-    fun getExitCode(matrices: MatrixMap): Int {
-        val savedMatrices = matrices.map.values
-        var exitCode = 0
-        savedMatrices.forEach { matrix ->
-            when (matrix.state) {
-                MatrixState.ERROR,
-                MatrixState.UNSUPPORTED_ENVIRONMENT,
-                MatrixState.INCOMPATIBLE_ENVIRONMENT,
-                MatrixState.INCOMPATIBLE_ARCHITECTURE,
-                MatrixState.CANCELLED,
-                MatrixState.INVALID -> {
-                    return 2
-                }
-                MatrixState.FINISHED -> {
-                    if (matrix.outcome != Outcome.success) {
-                        exitCode = 1
-                        if (matrix.outcome != Outcome.failure) {
-                            return 2
-                        }
-                    }
-                }
-            }
-        }
-        return exitCode
     }
 }

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/CancelCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/CancelCommandTest.kt
@@ -6,6 +6,7 @@ import ftl.cli.firebase.test.android.AndroidRunCommand
 import ftl.test.util.FlankTestRunner
 import org.junit.Rule
 import org.junit.Test
+import org.junit.contrib.java.lang.system.ExpectedSystemExit
 import org.junit.contrib.java.lang.system.SystemOutRule
 import org.junit.runner.RunWith
 import picocli.CommandLine
@@ -15,6 +16,9 @@ class CancelCommandTest {
     @Rule
     @JvmField
     val systemOutRule: SystemOutRule = SystemOutRule().enableLog().muteForSuccessfulTests()
+
+    @get:Rule
+    val exit = ExpectedSystemExit.none()
 
     @Test
     fun cancelCommandPrintsHelp() {
@@ -43,6 +47,7 @@ class CancelCommandTest {
 
     @Test
     fun cancelCommandRuns() {
+        exit.expectSystemExit()
         AndroidRunCommand().run()
         CancelCommand().run()
         val output = systemOutRule.log

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/RefreshCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/RefreshCommandTest.kt
@@ -5,6 +5,7 @@ import com.google.common.truth.Truth.assertThat
 import ftl.test.util.FlankTestRunner
 import org.junit.Rule
 import org.junit.Test
+import org.junit.contrib.java.lang.system.ExpectedSystemExit
 import org.junit.contrib.java.lang.system.SystemOutRule
 import org.junit.runner.RunWith
 import picocli.CommandLine
@@ -14,6 +15,9 @@ class RefreshCommandTest {
     @Rule
     @JvmField
     val systemOutRule: SystemOutRule = SystemOutRule().enableLog().muteForSuccessfulTests()
+
+    @get:Rule
+    val exit = ExpectedSystemExit.none()
 
     @Test
     fun refreshCommandPrintsHelp() {
@@ -42,6 +46,7 @@ class RefreshCommandTest {
 
     @Test
     fun refreshCommandRuns() {
+        exit.expectSystemExit()
         RefreshCommand().run()
         val output = systemOutRule.log
         Truth.assertThat(output).contains("1 / 1 (100.00%)")

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/AndroidRunCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/AndroidRunCommandTest.kt
@@ -6,6 +6,7 @@ import ftl.config.FtlConstants
 import ftl.test.util.FlankTestRunner
 import org.junit.Rule
 import org.junit.Test
+import org.junit.contrib.java.lang.system.ExpectedSystemExit
 import org.junit.contrib.java.lang.system.SystemOutRule
 import org.junit.runner.RunWith
 import picocli.CommandLine
@@ -15,6 +16,9 @@ class AndroidRunCommandTest {
     @Rule
     @JvmField
     val systemOutRule: SystemOutRule = SystemOutRule().enableLog().muteForSuccessfulTests()
+
+    @get:Rule
+    val exit = ExpectedSystemExit.none()
 
     @Test
     fun androidRunCommandPrintsHelp() {
@@ -46,6 +50,7 @@ class AndroidRunCommandTest {
 
     @Test
     fun androidRunCommandRuns() {
+        exit.expectSystemExit()
         AndroidRunCommand().run()
         val output = systemOutRule.log
         assertThat(output).contains("1 / 1 (100.00%)")

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/IosRunCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/ios/IosRunCommandTest.kt
@@ -9,12 +9,16 @@ import org.junit.Test
 import org.junit.contrib.java.lang.system.SystemOutRule
 import org.junit.runner.RunWith
 import picocli.CommandLine
+import org.junit.contrib.java.lang.system.ExpectedSystemExit
 
 @RunWith(FlankTestRunner::class)
 class IosRunCommandTest {
     @Rule
     @JvmField
     val systemOutRule: SystemOutRule = SystemOutRule().enableLog().muteForSuccessfulTests()
+
+    @get:Rule
+    val exit = ExpectedSystemExit.none()
 
     @Test
     fun iosRunCommandPrintsHelp() {
@@ -46,6 +50,7 @@ class IosRunCommandTest {
 
     @Test
     fun iosRunCommandRuns() {
+        exit.expectSystemExit()
         IosRunCommand().run()
         val output = systemOutRule.log
         Truth.assertThat(output).contains("1 / 1 (100.00%)")

--- a/test_runner/src/test/kotlin/ftl/fixtures/error_result/matrix_ids.json
+++ b/test_runner/src/test/kotlin/ftl/fixtures/error_result/matrix_ids.json
@@ -7,7 +7,8 @@
     "downloaded": true,
     "billableVirtualMinutes": 2,
     "billablePhysicalMinutes": 0,
-    "outcome": "failure"
+    "outcome": "failure",
+    "outcomeAdditionalDetails": "Mock Failed Reason"
   },
   "matrix-iio3vk6eoqwqa": {
     "matrixId": "matrix-iio3vk6eoqwqa",
@@ -18,5 +19,16 @@
     "billableVirtualMinutes": 2,
     "billablePhysicalMinutes": 0,
     "outcome": "failure"
+  },
+  "matrix-teex1a295m1ty": {
+    "matrixId": "matrix-teex1a295m1ty",
+    "state": "ERROR",
+    "gcsPath": "test-lab-jwwvtzdh5d20w-yyju9fnudnpts/2018-09-09_00:14:41.810000_bKxI/shard_1",
+    "webLink": "https://console.firebase.google.com/project/delta-essence-114723/testlab/histories/bh.58317d9cd7ab9ba2/matrices/7994869754124771736/executions/bs.795779ba6b096d51",
+    "downloaded": true,
+    "billableVirtualMinutes": 2,
+    "billablePhysicalMinutes": 0,
+    "outcome": "inconclusive",
+    "outcomeAdditionalDetails": "abortedByUser"
   }
 }

--- a/test_runner/src/test/kotlin/ftl/json/MatrixMapTest.kt
+++ b/test_runner/src/test/kotlin/ftl/json/MatrixMapTest.kt
@@ -1,34 +1,47 @@
 package ftl.json
 
+import com.google.api.services.testing.model.TestMatrix
 import com.google.common.truth.Truth.assertThat
+import ftl.json.SavedMatrixTest.Companion.createResultsStorage
+import ftl.json.SavedMatrixTest.Companion.createStepExecution
 import ftl.test.util.FlankTestRunner
-import ftl.util.Outcome
+import ftl.util.MatrixState
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito.`when`
-import org.mockito.Mockito.mock
 
 @RunWith(FlankTestRunner::class)
 class MatrixMapTest {
 
     @Test
     fun matrixMap_successful() {
-        val successMatrix = mock(SavedMatrix::class.java)
-        `when`(successMatrix.outcome).thenReturn(Outcome.success)
-        val matrixMap = MatrixMap(mutableMapOf("" to successMatrix, "" to successMatrix), "")
+        val successMatrix1 = matrixForExecution(0)
+        val successMatrix2 = matrixForExecution(0)
+        val matrixMap = MatrixMap(mutableMapOf("a" to successMatrix1, "b" to successMatrix2), "")
 
         assertThat(matrixMap.allSuccessful()).isTrue()
         assertThat(matrixMap.runPath).isNotNull()
         assertThat(matrixMap.map).isNotNull()
     }
 
+    private fun matrixForExecution(executionId: Int): SavedMatrix {
+        return SavedMatrix(
+            TestMatrix()
+                .setResultStorage(createResultsStorage())
+                .setState(MatrixState.FINISHED)
+                .setTestMatrixId("123")
+                .setTestExecutions(
+                    listOf(
+                        createStepExecution(executionId, "")
+                    )
+                )
+        )
+    }
+
     @Test
     fun matrixMap_failure() {
-        val successMatrix = mock(SavedMatrix::class.java)
-        `when`(successMatrix.outcome).thenReturn(Outcome.success)
-        val failedMatrix = mock(SavedMatrix::class.java)
-        `when`(successMatrix.outcome).thenReturn(Outcome.failure)
-        val matrixMap = MatrixMap(mutableMapOf("" to failedMatrix, "" to successMatrix), "")
+        val successMatrix = matrixForExecution(0) // 0 = success
+        val failureMatrix = matrixForExecution(-1) // -1 = failure
+        val matrixMap = MatrixMap(mutableMapOf("a" to failureMatrix, "b" to successMatrix), "")
 
         assertThat(matrixMap.allSuccessful()).isFalse()
     }

--- a/test_runner/src/test/kotlin/ftl/json/SavedMatrixTest.kt
+++ b/test_runner/src/test/kotlin/ftl/json/SavedMatrixTest.kt
@@ -19,34 +19,36 @@ import org.junit.runner.RunWith
 @RunWith(FlankTestRunner::class)
 class SavedMatrixTest {
 
-    // use -1 step id to get a failure outcome from the mock server
-    fun createStepExecution(stepId: Int, deviceModel: String = "shamu"): TestExecution {
-        val toolResultsStep = ToolResultsStep()
-        toolResultsStep.projectId = "1"
-        toolResultsStep.historyId = "2"
-        toolResultsStep.executionId = "3"
-        toolResultsStep.stepId = stepId.toString()
+    companion object {
+        // use -1 step id to get a failure outcome from the mock server
+        fun createStepExecution(stepId: Int, deviceModel: String = "shamu"): TestExecution {
+            val toolResultsStep = ToolResultsStep()
+            toolResultsStep.projectId = "1"
+            toolResultsStep.historyId = "2"
+            toolResultsStep.executionId = "3"
+            toolResultsStep.stepId = stepId.toString()
 
-        val testExecution = TestExecution()
-        testExecution.toolResultsStep = toolResultsStep
+            val testExecution = TestExecution()
+            testExecution.toolResultsStep = toolResultsStep
 
-        val androidDevice = GcAndroidDevice.build(Device(deviceModel, "23"))
-        testExecution.environment = Environment().setAndroidDevice(androidDevice)
+            val androidDevice = GcAndroidDevice.build(Device(deviceModel, "23"))
+            testExecution.environment = Environment().setAndroidDevice(androidDevice)
 
-        return testExecution
-    }
+            return testExecution
+        }
 
-    private val mockFileName = "mockFileName"
-    private val mockBucket = "mockBucket"
-    private val mockGcsPath = "$mockBucket/$mockFileName"
+        private val mockFileName = "mockFileName"
+        private val mockBucket = "mockBucket"
+        private val mockGcsPath = "$mockBucket/$mockFileName"
 
-    fun createResultsStorage(): ResultStorage {
-        val googleCloudStorage = GoogleCloudStorage()
-        googleCloudStorage.gcsPath = mockGcsPath
+        fun createResultsStorage(): ResultStorage {
+            val googleCloudStorage = GoogleCloudStorage()
+            googleCloudStorage.gcsPath = mockGcsPath
 
-        val resultsStorage = ResultStorage()
-        resultsStorage.googleCloudStorage = googleCloudStorage
-        return resultsStorage
+            val resultsStorage = ResultStorage()
+            resultsStorage.googleCloudStorage = googleCloudStorage
+            return resultsStorage
+        }
     }
 
     @Test
@@ -79,7 +81,7 @@ class SavedMatrixTest {
         assertThat(savedMatrix.billablePhysicalMinutes).isEqualTo(2)
         assertThat(savedMatrix.gcsPathWithoutRootBucket).isEqualTo(mockFileName)
         assertThat(savedMatrix.gcsRootBucket).isEqualTo(mockBucket)
-        assertThat(savedMatrix.outcomeAdditionalDetails).isNotEmpty()
+        assertThat(savedMatrix.outcomeDetails).isNotEmpty()
     }
 
     @Test
@@ -111,7 +113,7 @@ class SavedMatrixTest {
         assertThat(savedMatrix.billablePhysicalMinutes).isEqualTo(1)
         assertThat(savedMatrix.gcsPathWithoutRootBucket).isEqualTo(mockFileName)
         assertThat(savedMatrix.gcsRootBucket).isEqualTo(mockBucket)
-        assertThat(savedMatrix.outcomeAdditionalDetails).isNotEmpty()
+        assertThat(savedMatrix.outcomeDetails).isNotEmpty()
     }
 
     @Test

--- a/test_runner/src/test/kotlin/ftl/run/GenericTestRunnerTest.kt
+++ b/test_runner/src/test/kotlin/ftl/run/GenericTestRunnerTest.kt
@@ -2,12 +2,15 @@ package ftl.run
 
 import ftl.args.IArgs
 import ftl.run.GenericTestRunner.beforeRunMessage
+import ftl.test.util.FlankTestRunner
 import ftl.test.util.TestHelper.assert
 import ftl.util.Utils.trimStartLine
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 
+@RunWith(FlankTestRunner::class)
 class GenericTestRunnerTest {
 
     private fun createMock(repeatTests: Int, testShardChunks: List<List<String>>): IArgs {

--- a/test_runner/src/test/kotlin/ftl/test/util/MockServer.kt
+++ b/test_runner/src/test/kotlin/ftl/test/util/MockServer.kt
@@ -20,10 +20,15 @@ import com.google.api.services.toolresults.model.ProjectSettings
 import com.google.api.services.toolresults.model.Step
 import com.google.api.services.toolresults.model.TestExecutionStep
 import com.google.api.services.toolresults.model.TestTiming
+import com.google.api.services.toolresults.model.FailureDetail
+import com.google.api.services.toolresults.model.InconclusiveDetail
+import com.google.api.services.toolresults.model.SkippedDetail
 import com.google.gson.GsonBuilder
 import com.google.gson.LongSerializationPolicy
 import ftl.config.FtlConstants.JSON_FACTORY
 import ftl.util.Outcome.failure
+import ftl.util.Outcome.inconclusive
+import ftl.util.Outcome.skipped
 import ftl.util.Outcome.success
 import io.ktor.application.call
 import io.ktor.application.install
@@ -154,10 +159,26 @@ object MockServer {
                         .setTestTiming(testTiming)
 
                     val outcome = Outcome()
-                    outcome.summary = if (stepId == "-1") {
-                        failure
-                    } else {
-                        success
+                    when (stepId) {
+                        "-1" -> {
+                            outcome.summary = failure
+                            val failureDetail = FailureDetail()
+                            failureDetail.timedOut = true
+                            outcome.failureDetail = failureDetail
+                        }
+                        "-2" -> {
+                        outcome.summary = inconclusive
+                        val inconclusiveDetail = InconclusiveDetail()
+                        inconclusiveDetail.abortedByUser = true
+                        outcome.inconclusiveDetail = inconclusiveDetail
+                        }
+                        "-3" -> {
+                            outcome.summary = skipped
+                            val skippedDetail = SkippedDetail()
+                            skippedDetail.incompatibleAppVersion = true
+                            outcome.skippedDetail = skippedDetail
+                        }
+                        else -> outcome.summary = success
                     }
 
                     val step = Step()

--- a/test_runner/src/test/kotlin/ftl/test/util/MockServer.kt
+++ b/test_runner/src/test/kotlin/ftl/test/util/MockServer.kt
@@ -26,10 +26,10 @@ import com.google.api.services.toolresults.model.SkippedDetail
 import com.google.gson.GsonBuilder
 import com.google.gson.LongSerializationPolicy
 import ftl.config.FtlConstants.JSON_FACTORY
-import ftl.util.Outcome.failure
-import ftl.util.Outcome.inconclusive
-import ftl.util.Outcome.skipped
-import ftl.util.Outcome.success
+import ftl.util.StepOutcome.failure
+import ftl.util.StepOutcome.inconclusive
+import ftl.util.StepOutcome.skipped
+import ftl.util.StepOutcome.success
 import io.ktor.application.call
 import io.ktor.application.install
 import io.ktor.features.ContentNegotiation

--- a/test_runner/src/test/kotlin/ftl/util/OutcomeTest.kt
+++ b/test_runner/src/test/kotlin/ftl/util/OutcomeTest.kt
@@ -7,8 +7,8 @@ class OutcomeTest {
 
     @Test
     fun outcome_isNotEmpty() {
-        assertThat(Outcome.failure).isNotEmpty()
-        assertThat(Outcome.success).isNotEmpty()
-        assertThat(Outcome).isNotNull()
+        assertThat(StepOutcome.failure).isNotEmpty()
+        assertThat(StepOutcome.success).isNotEmpty()
+        assertThat(StepOutcome).isNotNull()
     }
 }

--- a/test_runner/src/test/kotlin/ftl/util/UtilsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/util/UtilsTest.kt
@@ -4,7 +4,8 @@ import com.google.api.services.testing.model.TestMatrix
 import com.google.common.truth.Truth.assertThat
 import ftl.json.MatrixMap
 import ftl.json.SavedMatrix
-import ftl.json.SavedMatrixTest
+import ftl.json.SavedMatrixTest.Companion.createResultsStorage
+import ftl.json.SavedMatrixTest.Companion.createStepExecution
 import ftl.test.util.FlankTestRunner
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -24,83 +25,63 @@ class UtilsTest {
 
     @Test
     fun testExitCodeForFailed() {
-        // Given
-        var savedMatrixTest = SavedMatrixTest()
         val testExecutions = listOf(
-            savedMatrixTest.createStepExecution(1, "Success"),
-            savedMatrixTest.createStepExecution(-1, "Failed")
+            createStepExecution(1, "Success"),
+            createStepExecution(-1, "Failed")
         )
         val testMatrix = TestMatrix()
         testMatrix.testMatrixId = "123"
         testMatrix.state = MatrixState.FINISHED
-        testMatrix.resultStorage = savedMatrixTest.createResultsStorage()
+        testMatrix.resultStorage = createResultsStorage()
         testMatrix.testExecutions = testExecutions
         val finishedMatrix = SavedMatrix(testMatrix)
         val matrixMap = MatrixMap(mutableMapOf("finishedMatrix" to finishedMatrix), "MockPath")
-        // When
-        var exitCode = Utils.getExitCode(matrixMap)
-        // Then
-        assertThat(exitCode).isEqualTo(1)
+        assertThat(matrixMap.exitCode()).isEqualTo(1)
     }
 
     @Test
     fun testExitCodeForSuccess() {
-        // Given
-        var savedMatrixTest = SavedMatrixTest()
         val testExecutions = listOf(
-            savedMatrixTest.createStepExecution(1, "Success")
+            createStepExecution(1, "Success")
         )
         val testMatrix = TestMatrix()
         testMatrix.testMatrixId = "123"
         testMatrix.state = MatrixState.FINISHED
-        testMatrix.resultStorage = savedMatrixTest.createResultsStorage()
+        testMatrix.resultStorage = createResultsStorage()
         testMatrix.testExecutions = testExecutions
         val finishedMatrix = SavedMatrix(testMatrix)
         val matrixMap = MatrixMap(mutableMapOf("" to finishedMatrix), "MockPath")
-        // When
-        var exitCode = Utils.getExitCode(matrixMap)
-        // Then
-        assertThat(exitCode).isEqualTo(0)
+        assertThat(matrixMap.exitCode()).isEqualTo(0)
     }
 
     @Test
-    fun testExitCodeForInconclusive() {
-        // Given
-        var savedMatrixTest = SavedMatrixTest()
+    fun testExitCodeForInconclusive() { // inconclusive is treated as a failure
         val testExecutions = listOf(
-            savedMatrixTest.createStepExecution(-2, "Inconclusive")
+            createStepExecution(-2, "Inconclusive")
         )
         val testMatrix = TestMatrix()
         testMatrix.testMatrixId = "123"
         testMatrix.state = MatrixState.FINISHED
-        testMatrix.resultStorage = savedMatrixTest.createResultsStorage()
+        testMatrix.resultStorage = createResultsStorage()
         testMatrix.testExecutions = testExecutions
         val finishedMatrix = SavedMatrix(testMatrix)
         val matrixMap = MatrixMap(mutableMapOf("" to finishedMatrix), "MockPath")
-        // When
-        var exitCode = Utils.getExitCode(matrixMap)
-        // Then
-        assertThat(exitCode).isEqualTo(2)
+        assertThat(matrixMap.exitCode()).isEqualTo(1)
     }
 
     @Test
     fun testExitCodeForError() {
-        // Given
-        var savedMatrixTest = SavedMatrixTest()
         val testExecutions = listOf(
-            savedMatrixTest.createStepExecution(-2, "Inconclusive"),
-            savedMatrixTest.createStepExecution(-3, "Skipped")
+            createStepExecution(-2, "Inconclusive"),
+            createStepExecution(-3, "Skipped")
         )
         val testMatrix = TestMatrix()
         testMatrix.testMatrixId = "123"
         testMatrix.state = MatrixState.ERROR
-        testMatrix.resultStorage = savedMatrixTest.createResultsStorage()
+        testMatrix.resultStorage = createResultsStorage()
         testMatrix.testExecutions = testExecutions
         val errorMatrix = SavedMatrix(testMatrix)
         val matrixMap = MatrixMap(mutableMapOf("errorMatrix" to errorMatrix), "MockPath")
-        // When
-        var exitCode = Utils.getExitCode(matrixMap)
-        // Then
-        assertThat(exitCode).isEqualTo(2)
+        assertThat(matrixMap.exitCode()).isEqualTo(2)
     }
 }

--- a/test_runner/src/test/kotlin/ftl/util/UtilsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/util/UtilsTest.kt
@@ -1,8 +1,15 @@
 package ftl.util
 
+import com.google.api.services.testing.model.TestMatrix
 import com.google.common.truth.Truth.assertThat
+import ftl.json.MatrixMap
+import ftl.json.SavedMatrix
+import ftl.json.SavedMatrixTest
+import ftl.test.util.FlankTestRunner
 import org.junit.Test
+import org.junit.runner.RunWith
 
+@RunWith(FlankTestRunner::class)
 class UtilsTest {
 
     @Test(expected = RuntimeException::class)
@@ -13,5 +20,87 @@ class UtilsTest {
     @Test
     fun readTextResource_succeeds() {
         assertThat(Utils.readTextResource("version.txt")).isNotNull()
+    }
+
+    @Test
+    fun testExitCodeForFailed() {
+        // Given
+        var savedMatrixTest = SavedMatrixTest()
+        val testExecutions = listOf(
+            savedMatrixTest.createStepExecution(1, "Success"),
+            savedMatrixTest.createStepExecution(-1, "Failed")
+        )
+        val testMatrix = TestMatrix()
+        testMatrix.testMatrixId = "123"
+        testMatrix.state = MatrixState.FINISHED
+        testMatrix.resultStorage = savedMatrixTest.createResultsStorage()
+        testMatrix.testExecutions = testExecutions
+        val finishedMatrix = SavedMatrix(testMatrix)
+        val matrixMap = MatrixMap(mutableMapOf("finishedMatrix" to finishedMatrix), "MockPath")
+        // When
+        var exitCode = Utils.getExitCode(matrixMap)
+        // Then
+        assertThat(exitCode).isEqualTo(1)
+    }
+
+    @Test
+    fun testExitCodeForSuccess() {
+        // Given
+        var savedMatrixTest = SavedMatrixTest()
+        val testExecutions = listOf(
+            savedMatrixTest.createStepExecution(1, "Success")
+        )
+        val testMatrix = TestMatrix()
+        testMatrix.testMatrixId = "123"
+        testMatrix.state = MatrixState.FINISHED
+        testMatrix.resultStorage = savedMatrixTest.createResultsStorage()
+        testMatrix.testExecutions = testExecutions
+        val finishedMatrix = SavedMatrix(testMatrix)
+        val matrixMap = MatrixMap(mutableMapOf("" to finishedMatrix), "MockPath")
+        // When
+        var exitCode = Utils.getExitCode(matrixMap)
+        // Then
+        assertThat(exitCode).isEqualTo(0)
+    }
+
+    @Test
+    fun testExitCodeForInconclusive() {
+        // Given
+        var savedMatrixTest = SavedMatrixTest()
+        val testExecutions = listOf(
+            savedMatrixTest.createStepExecution(-2, "Inconclusive")
+        )
+        val testMatrix = TestMatrix()
+        testMatrix.testMatrixId = "123"
+        testMatrix.state = MatrixState.FINISHED
+        testMatrix.resultStorage = savedMatrixTest.createResultsStorage()
+        testMatrix.testExecutions = testExecutions
+        val finishedMatrix = SavedMatrix(testMatrix)
+        val matrixMap = MatrixMap(mutableMapOf("" to finishedMatrix), "MockPath")
+        // When
+        var exitCode = Utils.getExitCode(matrixMap)
+        // Then
+        assertThat(exitCode).isEqualTo(2)
+    }
+
+    @Test
+    fun testExitCodeForError() {
+        // Given
+        var savedMatrixTest = SavedMatrixTest()
+        val testExecutions = listOf(
+            savedMatrixTest.createStepExecution(-2, "Inconclusive"),
+            savedMatrixTest.createStepExecution(-3, "Skipped")
+        )
+        val testMatrix = TestMatrix()
+        testMatrix.testMatrixId = "123"
+        testMatrix.state = MatrixState.ERROR
+        testMatrix.resultStorage = savedMatrixTest.createResultsStorage()
+        testMatrix.testExecutions = testExecutions
+        val errorMatrix = SavedMatrix(testMatrix)
+        val matrixMap = MatrixMap(mutableMapOf("errorMatrix" to errorMatrix), "MockPath")
+        // When
+        var exitCode = Utils.getExitCode(matrixMap)
+        // Then
+        assertThat(exitCode).isEqualTo(2)
     }
 }


### PR DESCRIPTION
- Improved Exit Code based on the execution outcome and state.

- Updated MatrixResultReport to include additional details.

Sample **MatrixResultReport** Looks like below
```
MatrixResultsReport
  0 / 2 (0.00%)
  2 matrices failed

  Failed matrix:
    Matrix Id: matrix-teex1a295m17a
    Reason: abortedByUser
    Web Link: https://console.firebase.google.com/project/delta-essence-114723/testlab/histories/bh.58317d9cd7ab9ba2/matrices/7994869754124771736/executions/bs.795779ba6b096d51

  Failed matrix:
    Matrix Id: matrix-iio3vk6eoqwqa
    Web Link: https://console.firebase.google.com/project/delta-essence-114723/testlab/histories/bh.58317d9cd7ab9ba2/matrices/6325378892669071099/executions/bs.b6517c0e72b114f1

```

Fix #329 