### PR TITLE
Modify the WebLink to point to the matrix root if there are more than one device

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,12 +124,14 @@ Stable
 
 ```
 wget --quiet https://github.com/TestArmada/flank/releases/download/v3.0.0/flank.jar -O ./flank.jar
+java -jar ./flank.jar android run
 ```
 
 Snapshot (published after every commit)
 
 ```
 wget --quiet https://github.com/TestArmada/flank/releases/download/flank_snapshot/flank.jar -O ./flank.jar
+java -jar ./flank.jar android run
 ```
 
 In CI, it may be useful to generate the file via a shell script:

--- a/test_runner/src/main/kotlin/ftl/util/TestMatrixExtension.kt
+++ b/test_runner/src/main/kotlin/ftl/util/TestMatrixExtension.kt
@@ -8,9 +8,15 @@ fun TestMatrix.firstToolResults(): ToolResultsStep? {
 }
 
 fun TestMatrix.webLink(): String {
+    val numDevices = testExecutions?.size ?: 0
     val firstStep: ToolResultsStep = firstToolResults() ?: return ""
-    return "https://console.firebase.google.com/project/${this.projectId}/" +
-        "testlab/histories/${firstStep.historyId}/" +
-        "matrices/${firstStep.executionId}/" +
-        "executions/${firstStep.stepId}"
+
+    val baseUrl =
+        "https://console.firebase.google.com/project/${this.projectId}/testlab/histories/${firstStep.historyId}"
+    return if (numDevices == 1) {
+        "$baseUrl/executions/${firstStep.stepId}"
+    } else {
+        baseUrl
+    }
+
 }

--- a/test_runner/src/main/kotlin/ftl/util/TestMatrixExtension.kt
+++ b/test_runner/src/main/kotlin/ftl/util/TestMatrixExtension.kt
@@ -12,7 +12,9 @@ fun TestMatrix.webLink(): String {
     val firstStep: ToolResultsStep = firstToolResults() ?: return ""
 
     val baseUrl =
-        "https://console.firebase.google.com/project/${this.projectId}/testlab/histories/${firstStep.historyId}"
+        "https://console.firebase.google.com/project/${this.projectId}/" +
+                "testlab/histories/${firstStep.historyId}/" +
+                "matrices/${firstStep.executionId}"
     return if (numDevices == 1) {
         "$baseUrl/executions/${firstStep.stepId}"
     } else {

--- a/test_runner/src/main/kotlin/ftl/util/TestMatrixExtension.kt
+++ b/test_runner/src/main/kotlin/ftl/util/TestMatrixExtension.kt
@@ -18,5 +18,4 @@ fun TestMatrix.webLink(): String {
     } else {
         baseUrl
     }
-
 }

--- a/test_runner/src/test/kotlin/ftl/json/SavedMatrixTest.kt
+++ b/test_runner/src/test/kotlin/ftl/json/SavedMatrixTest.kt
@@ -75,7 +75,7 @@ class SavedMatrixTest {
         assertThat(savedMatrix.matrixId).isEqualTo(matrixId)
         assertThat(savedMatrix.state).isEqualTo(matrixState)
         assertThat(savedMatrix.gcsPath).isEqualTo(mockGcsPath)
-        assertThat(savedMatrix.webLink).isEqualTo("https://console.firebase.google.com/project/null/testlab/histories/2/matrices/3/executions/-1")
+        assertThat(savedMatrix.webLink).isEqualTo("https://console.firebase.google.com/project/null/testlab/histories/2/matrices/3")
         assertThat(savedMatrix.downloaded).isFalse()
         assertThat(savedMatrix.billableVirtualMinutes).isEqualTo(0)
         assertThat(savedMatrix.billablePhysicalMinutes).isEqualTo(2)


### PR DESCRIPTION
Previously, if a matrix had multiple devices, the link would take you into the details of the first device.

Expected:
![image](https://user-images.githubusercontent.com/3683106/48101091-bfb17b80-e1da-11e8-99d6-fc1b4bbebf41.png)
Actual:
![image](https://user-images.githubusercontent.com/3683106/48101114-cc35d400-e1da-11e8-8a60-10cfa5929bf6.png)


Now, if there's a single device, it will take you directly to the execution. But if there are multiple devices, it will take you to the root matrix page which lists all the devices.

So, for **ONE** device, you'll still see the execution as before ( second screenshot above ). But for **MULTIPLE** devices, you'll see the matrix base screen ( first screenshot above ).