### PR TITLE
Refactor all references of config to args

### DIFF
--- a/test_runner/src/main/kotlin/ftl/gc/GcStorage.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/GcStorage.kt
@@ -40,25 +40,25 @@ object GcStorage {
             runGcsPath = runGcsPath
         )
 
-    fun uploadAppApk(config: AndroidArgs, gcsBucket: String, runGcsPath: String): String =
-        upload(config.appApk, gcsBucket, runGcsPath)
+    fun uploadAppApk(args: AndroidArgs, gcsBucket: String, runGcsPath: String): String =
+        upload(args.appApk, gcsBucket, runGcsPath)
 
-    fun uploadTestApk(config: AndroidArgs, gcsBucket: String, runGcsPath: String): String =
-        upload(config.testApk, gcsBucket, runGcsPath)
+    fun uploadTestApk(args: AndroidArgs, gcsBucket: String, runGcsPath: String): String =
+        upload(args.testApk, gcsBucket, runGcsPath)
 
-    fun uploadXCTestZip(config: IosArgs, runGcsPath: String): String =
-        upload(config.xctestrunZip, config.resultsBucket, runGcsPath)
+    fun uploadXCTestZip(args: IosArgs, runGcsPath: String): String =
+        upload(args.xctestrunZip, args.resultsBucket, runGcsPath)
 
-    fun uploadXCTestFile(config: IosArgs, gcsBucket: String, runGcsPath: String, fileBytes: ByteArray): String =
+    fun uploadXCTestFile(args: IosArgs, gcsBucket: String, runGcsPath: String, fileBytes: ByteArray): String =
         upload(
-            file = config.xctestrunFile,
+            file = args.xctestrunFile,
             fileBytes = fileBytes,
             rootGcsBucket = gcsBucket,
             runGcsPath = runGcsPath
         )
 
-    fun downloadTestApk(config: AndroidArgs): String =
-        download(config.testApk)
+    fun downloadTestApk(args: AndroidArgs): String =
+        download(args.testApk)
 
     private fun upload(file: String, fileBytes: ByteArray, rootGcsBucket: String, runGcsPath: String): String {
         val fileName = Paths.get(file).fileName.toString()

--- a/test_runner/src/main/kotlin/ftl/gc/GcTestMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/GcTestMatrix.kt
@@ -33,8 +33,8 @@ object GcTestMatrix {
     //        "message" : "The service is currently unavailable.",
     //        "status" : "UNAVAILABLE"
     //    }
-    fun refresh(testMatrixId: String, config: IArgs): TestMatrix {
-        val getMatrix = GcTesting.get.projects().testMatrices().get(config.projectId, testMatrixId)
+    fun refresh(testMatrixId: String, args: IArgs): TestMatrix {
+        val getMatrix = GcTesting.get.projects().testMatrices().get(args.projectId, testMatrixId)
         var failed = 0
         val maxWait = ofHours(1).seconds
 
@@ -50,8 +50,8 @@ object GcTestMatrix {
         throw RuntimeException("Failed to refresh matrix")
     }
 
-    fun cancel(testMatrixId: String, config: IArgs): CancelTestMatrixResponse {
-        val cancelMatrix = GcTesting.get.projects().testMatrices().cancel(config.projectId, testMatrixId)
+    fun cancel(testMatrixId: String, args: IArgs): CancelTestMatrixResponse {
+        val cancelMatrix = GcTesting.get.projects().testMatrices().cancel(args.projectId, testMatrixId)
         var failed = 0
         val maxTries = 3
 

--- a/test_runner/src/main/kotlin/ftl/reports/util/ReportManager.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/util/ReportManager.kt
@@ -63,8 +63,8 @@ object ReportManager {
     }
 
     /** Returns true if there were no test failures */
-    fun generate(matrices: MatrixMap, config: IArgs): Int {
-        val iosXml = config is IosArgs
+    fun generate(matrices: MatrixMap, args: IArgs): Int {
+        val iosXml = args is IosArgs
         val testSuite = if (iosXml) {
             processXml(matrices, ::parseIosXml)
         } else {

--- a/test_runner/src/main/kotlin/ftl/run/AndroidTestRunner.kt
+++ b/test_runner/src/main/kotlin/ftl/run/AndroidTestRunner.kt
@@ -40,7 +40,7 @@ object AndroidTestRunner {
                         runGcsPath = runGcsPath,
                         androidDeviceList = androidDeviceList,
                         testShardsIndex = testShardsIndex,
-                        config = androidArgs,
+                        args = androidArgs,
                         shardCounter = shardCounter,
                         toolResultsHistory = history
                     ).execute()
@@ -56,23 +56,23 @@ object AndroidTestRunner {
      *
      * @return Pair(gcs uri for app apk, gcs uri for test apk)
      */
-    private suspend fun resolveApks(config: AndroidArgs, runGcsPath: String): Pair<String, String> = coroutineScope {
-        val gcsBucket = config.resultsBucket
+    private suspend fun resolveApks(args: AndroidArgs, runGcsPath: String): Pair<String, String> = coroutineScope {
+        val gcsBucket = args.resultsBucket
 
         val appApkGcsPath = async {
-            if (!config.appApk.startsWith(FtlConstants.GCS_PREFIX)) {
-                GcStorage.uploadAppApk(config, gcsBucket, runGcsPath)
+            if (!args.appApk.startsWith(FtlConstants.GCS_PREFIX)) {
+                GcStorage.uploadAppApk(args, gcsBucket, runGcsPath)
             } else {
-                config.appApk
+                args.appApk
             }
         }
 
         val testApkGcsPath = async {
             // Skip download case for testApk - YamlConfig downloads it when it does validation
-            if (!config.testApk.startsWith(FtlConstants.GCS_PREFIX)) {
-                GcStorage.uploadTestApk(config, gcsBucket, runGcsPath)
+            if (!args.testApk.startsWith(FtlConstants.GCS_PREFIX)) {
+                GcStorage.uploadTestApk(args, gcsBucket, runGcsPath)
             } else {
-                config.testApk
+                args.testApk
             }
         }
 

--- a/test_runner/src/main/kotlin/ftl/run/IosTestRunner.kt
+++ b/test_runner/src/main/kotlin/ftl/run/IosTestRunner.kt
@@ -49,7 +49,7 @@ object IosTestRunner {
                         runGcsPath = runGcsPath,
                         testShardsIndex = testShardsIndex,
                         xcTestParsed = xcTestParsed,
-                        config = iosArgs,
+                        args = iosArgs,
                         shardCounter = shardCounter,
                         toolResultsHistory = history
                     ).execute()

--- a/test_runner/src/test/kotlin/ftl/args/AndroidArgsFileTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/AndroidArgsFileTest.kt
@@ -55,9 +55,9 @@ class AndroidArgsFileTest {
         checkConfig(config, false)
     }
 
-    private fun checkConfig(config: AndroidArgs, local: Boolean) {
+    private fun checkConfig(args: AndroidArgs, local: Boolean) {
 
-        with(config) {
+        with(args) {
             if (local) assert(getString(testApk), testApkLocal)
             else assert(testApk, testApkGcs)
 
@@ -83,7 +83,7 @@ class AndroidArgsFileTest {
             )
         }
 
-        with(config) {
+        with(args) {
             assert(testShards, 1)
             assert(repeatTests, 1)
         }


### PR DESCRIPTION
`config` and `args` were being synonymously used. But it's confusing to have two terms for the same thing.