### PR TITLE
Smart Flank

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,6 +1,7 @@
 ## v4.1 (unreleased)
 - `app`, `test`, and `xctestrun-file` now support `~`, environment variables, and globs (`*`, `**`) when resolving paths. [#386](https://github.com/TestArmada/flank/pull/386)
 - Update `flank android run` to support `--app`, `--test`, `--test-targets`, `--use-orchestrator` and `--no-use-orchestrator`.
+- Add `smartFlankGcsPath` to shard iOS and Android tests by time using historical run data. The amount of shards used is set by `testShards`.
 
 ## v4.0.0
 

--- a/test_runner/build.gradle.kts
+++ b/test_runner/build.gradle.kts
@@ -38,7 +38,9 @@ tasks.withType<JacocoReport> {
 }
 
 tasks.withType<KotlinCompile>().configureEach {
-    kotlinOptions.allWarningsAsErrors = false
+    // https://devcenter.bitrise.io/builds/available-environment-variables/
+    val runningOnBitrise = System.getenv("BITRISE_IO") != null
+    kotlinOptions.allWarningsAsErrors = runningOnBitrise
 }
 
 apply {

--- a/test_runner/build.gradle.kts
+++ b/test_runner/build.gradle.kts
@@ -38,7 +38,7 @@ tasks.withType<JacocoReport> {
 }
 
 tasks.withType<KotlinCompile>().configureEach {
-    kotlinOptions.allWarningsAsErrors = true
+    kotlinOptions.allWarningsAsErrors = false
 }
 
 apply {

--- a/test_runner/flank.ios.yml
+++ b/test_runner/flank.ios.yml
@@ -19,18 +19,25 @@ gcloud:
       orientation: portrait
 
 flank:
-  # Google cloud storage path to store the JUnit XML results from the last run.
-  junitGcsPath: gs://tmp_flank/flank/test_app_ios.xml
+  # # Google cloud storage path to store the JUnit XML results from the last run.
+  #
+  # smartFlankGcsPath: gs://tmp_flank/flank/test_app_ios.xml
+
   # test shards - the amount of groups to split the test suite into
   # set to -1 to use one shard per test.
   testShards: 2
+
   # repeat tests - the amount of times to run the tests.
   # 1 runs the tests once. 10 runs all the tests 10x
   repeatTests: 1
-  # always run - these tests are inserted at the beginning of every shard
-  # useful if you need to grant permissions or login before other tests run
+
+  # # always run - these tests are inserted at the beginning of every shard
+  # # useful if you need to grant permissions or login before other tests run
+  #
   # test-targets-always-run:
   #   - a/testGrantPermissions
-  # test targets - a list of tests to run. omit to run all tests.
+
+  # # test targets - a list of tests to run. omit to run all tests.
+  #
   # test-targets:
   #   - b/testBasicSelection

--- a/test_runner/flank.ios.yml
+++ b/test_runner/flank.ios.yml
@@ -11,7 +11,7 @@ gcloud:
   # test and xctestrun-file are the only required args
   test: ./src/test/kotlin/ftl/fixtures/tmp/EarlGreyExample.zip
   xctestrun-file: ./src/test/kotlin/ftl/fixtures/tmp/EarlGreyExampleSwiftTests_iphoneos12.1-arm64e.xctestrun
-  xcode-version: 9.2
+  xcode-version: 10.1
   device:
     - model: iphone8
       version: 11.2
@@ -19,9 +19,11 @@ gcloud:
       orientation: portrait
 
 flank:
+  # Google cloud storage path to store the JUnit XML results from the last run.
+  junitGcsPath: gs://tmp_flank/flank/test_app_ios.xml
   # test shards - the amount of groups to split the test suite into
   # set to -1 to use one shard per test.
-  testShards: 1
+  testShards: 2
   # repeat tests - the amount of times to run the tests.
   # 1 runs the tests once. 10 runs all the tests 10x
   repeatTests: 1

--- a/test_runner/flank.yml
+++ b/test_runner/flank.yml
@@ -27,9 +27,9 @@ gcloud:
       version: 28
 
 flank:
-  # Google cloud storage path to store the JUnit XML results from the last run.
+  # # Google cloud storage path to store the JUnit XML results from the last run.
   #
-  # junitGcsPath: gs://tmp_flank/flank/test_app_android.xml
+  # smartFlankGcsPath: gs://tmp_flank/flank/test_app_android.xml
 
   # test shards - the amount of groups to split the test suite into
   # set to -1 to use one shard per test.
@@ -41,8 +41,8 @@ flank:
   #
   repeatTests: 1
 
-  # always run - these tests are inserted at the beginning of every shard
-  # useful if you need to grant permissions or login before other tests run
+  # # always run - these tests are inserted at the beginning of every shard
+  # # useful if you need to grant permissions or login before other tests run
   #
   # test-targets-always-run:
-    # - class com.example.app.ExampleUiTest#testPasses
+  #   - class com.example.app.ExampleUiTest#testPasses

--- a/test_runner/flank.yml
+++ b/test_runner/flank.yml
@@ -27,13 +27,22 @@ gcloud:
       version: 28
 
 flank:
+  # Google cloud storage path to store the JUnit XML results from the last run.
+  #
+  # junitGcsPath: gs://tmp_flank/flank/test_app_android.xml
+
   # test shards - the amount of groups to split the test suite into
   # set to -1 to use one shard per test.
+  #
   testShards: 1
+
   # repeat tests - the amount of times to run the tests.
   # 1 runs the tests once. 10 runs all the tests 10x
+  #
   repeatTests: 1
+
   # always run - these tests are inserted at the beginning of every shard
   # useful if you need to grant permissions or login before other tests run
+  #
   # test-targets-always-run:
     # - class com.example.app.ExampleUiTest#testPasses

--- a/test_runner/src/main/kotlin/ftl/args/AndroidArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/AndroidArgs.kt
@@ -11,7 +11,9 @@ import ftl.args.ArgsHelper.assertFileExists
 import ftl.args.ArgsHelper.assertGcsFileExists
 import ftl.args.ArgsHelper.calculateShards
 import ftl.args.ArgsHelper.evaluateFilePath
-import ftl.args.ArgsHelper.getGcsBucket
+import ftl.args.ArgsHelper.createGcsBucket
+import ftl.args.ArgsHelper.createJunitBucket
+import ftl.args.ArgsHelper.evaluateFilePath
 import ftl.args.ArgsHelper.mergeYmlMaps
 import ftl.args.ArgsHelper.yamlMapper
 import ftl.args.ArgsToString.devicesToString
@@ -63,6 +65,7 @@ class AndroidArgs(
     private val flank = flankYml.flank
     override val testShards = flank.testShards
     override val repeatTests = flank.repeatTests
+    override val junitGcsPath = flank.junitGcsPath
     override val testTargetsAlwaysRun = flank.testTargetsAlwaysRun
 
     // computed properties not specified in yaml
@@ -85,7 +88,8 @@ class AndroidArgs(
     }
 
     init {
-        resultsBucket = getGcsBucket(projectId, gcloud.resultsBucket)
+        resultsBucket = createGcsBucket(projectId, gcloud.resultsBucket)
+        createJunitBucket(projectId, flank.junitGcsPath)
 
         if (appApk.startsWith(FtlConstants.GCS_PREFIX)) {
             assertGcsFileExists(appApk)
@@ -157,6 +161,7 @@ ${devicesToString(devices)}
     flank:
       testShards: $testShards
       repeatTests: $repeatTests
+      junitGcsPath: $junitGcsPath
       test-targets-always-run:
 ${listToString(testTargetsAlwaysRun)}
    """.trimIndent()

--- a/test_runner/src/main/kotlin/ftl/args/AndroidArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/AndroidArgs.kt
@@ -64,7 +64,7 @@ class AndroidArgs(
     private val flank = flankYml.flank
     override val testShards = flank.testShards
     override val repeatTests = flank.repeatTests
-    override val junitGcsPath = flank.junitGcsPath
+    override val smartFlankGcsPath = flank.smartFlankGcsPath
     override val testTargetsAlwaysRun = flank.testTargetsAlwaysRun
 
     // computed properties not specified in yaml
@@ -83,7 +83,7 @@ class AndroidArgs(
 
     init {
         resultsBucket = createGcsBucket(projectId, gcloud.resultsBucket)
-        createJunitBucket(projectId, flank.junitGcsPath)
+        createJunitBucket(projectId, flank.smartFlankGcsPath)
 
         if (appApk.startsWith(FtlConstants.GCS_PREFIX)) {
             assertGcsFileExists(appApk)
@@ -156,7 +156,7 @@ ${devicesToString(devices)}
     flank:
       testShards: $testShards
       repeatTests: $repeatTests
-      junitGcsPath: $junitGcsPath
+      smartFlankGcsPath: $smartFlankGcsPath
       test-targets-always-run:
 ${listToString(testTargetsAlwaysRun)}
    """.trimIndent()

--- a/test_runner/src/main/kotlin/ftl/args/AndroidArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/AndroidArgs.kt
@@ -9,8 +9,7 @@ import ftl.android.UnsupportedModelId
 import ftl.android.UnsupportedVersionId
 import ftl.args.ArgsHelper.assertFileExists
 import ftl.args.ArgsHelper.assertGcsFileExists
-import ftl.args.ArgsHelper.calculateShards
-import ftl.args.ArgsHelper.evaluateFilePath
+import ftl.args.ArgsHelper.convertShards
 import ftl.args.ArgsHelper.createGcsBucket
 import ftl.args.ArgsHelper.createJunitBucket
 import ftl.args.ArgsHelper.evaluateFilePath
@@ -28,6 +27,8 @@ import ftl.config.FtlConstants
 import ftl.config.FtlConstants.useMock
 import ftl.filter.TestFilters
 import ftl.gc.GcStorage
+import ftl.reports.xml.model.JUnitTestResult
+import ftl.shard.Shard
 import ftl.util.Utils
 import kotlinx.coroutines.runBlocking
 import java.nio.file.Files
@@ -79,12 +80,8 @@ class AndroidArgs(
         }
 
         val filteredTests = getTestMethods(testLocalApk)
-
-        calculateShards(
-            filteredTests,
-            testTargetsAlwaysRun,
-            testShards
-            )
+        val oldTestResult = GcStorage.downloadJunitXml(this) ?: JUnitTestResult(mutableListOf())
+        convertShards(Shard.calculateShardsByTime(filteredTests, oldTestResult, testShards)).toMutableList()
     }
 
     init {

--- a/test_runner/src/main/kotlin/ftl/args/ArgsFileVisitor.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ArgsFileVisitor.kt
@@ -1,6 +1,5 @@
 package ftl.args
 
-import ftl.util.Utils.fatalError
 import java.io.IOException
 import java.nio.file.FileSystems
 import java.nio.file.FileVisitOption
@@ -26,7 +25,8 @@ class ArgsFileVisitor(glob: String) : SimpleFileVisitor<Path>() {
     }
 
     override fun visitFileFailed(file: Path?, exc: IOException?): FileVisitResult {
-        fatalError("Failed to visit $file $exc")
+        // java.nio.file.AccessDeniedException: /tmp/systemd-private-2bc4cd4c824142ab95fb18cbb14165f5-systemd-timesyncd.service-epYUoK
+        System.err.println("Failed to visit $file ${exc?.message}")
         return FileVisitResult.CONTINUE
     }
 

--- a/test_runner/src/main/kotlin/ftl/args/ArgsHelper.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ArgsHelper.kt
@@ -11,16 +11,15 @@ import com.google.cloud.storage.BucketInfo
 import com.google.cloud.storage.Storage
 import com.google.cloud.storage.StorageClass
 import com.google.cloud.storage.StorageOptions
-import com.google.common.math.IntMath
 import ftl.args.yml.IYmlMap
 import ftl.config.FtlConstants
 import ftl.config.FtlConstants.GCS_PREFIX
 import ftl.config.FtlConstants.JSON_FACTORY
 import ftl.config.FtlConstants.defaultCredentialPath
 import ftl.gc.GcStorage
+import ftl.shard.TestShard
 import ftl.util.Utils
 import java.io.File
-import java.math.RoundingMode
 import java.net.URI
 import java.nio.file.Files
 import java.nio.file.Path
@@ -95,39 +94,10 @@ object ArgsHelper {
         if (validTestMethods.isEmpty()) Utils.fatalError("$from has no tests")
     }
 
-    fun calculateShards(
-        testMethodsToShard: Collection<String>,
-        testMethodsAlwaysRun: Collection<String>,
-        testShards: Int
-    ): List<List<String>> {
-        val testShardMethods = testMethodsToShard.distinct().toMutableList()
-        testShardMethods.removeAll(testMethodsAlwaysRun)
-
-        val oneTestPerChunk = testShards == -1
-        var chunkSize = IntMath.divide(testShardMethods.size, testShards, RoundingMode.UP)
-
-        if (oneTestPerChunk || chunkSize < 1) {
-            chunkSize = 1
-        }
-
-        val testShardChunks = testShardMethods.asSequence()
-            .chunked(chunkSize)
-            .map { testMethodsAlwaysRun + it }
-            .toList()
-
-        // Ensure we don't create more VMs than requested. VM count per run should be <= testShards
-        if (!oneTestPerChunk && testShardChunks.size > testShards) {
-            Utils.fatalError("Calculated chunks $testShardChunks is > requested $testShards testShards.")
-        }
-        if (testShardChunks.isEmpty()) Utils.fatalError("Failed to populate test shard chunks")
-
-        return testShardChunks
-    }
-
     fun createJunitBucket(projectId: String, junitGcsPath: String) {
         if (FtlConstants.useMock || junitGcsPath.isEmpty()) return
         val bucket = junitGcsPath.drop(GCS_PREFIX.length).substringBefore('/')
-        createGcsBucket(projectId, bucket)
+            createGcsBucket(projectId, bucket)
     }
 
     fun createGcsBucket(projectId: String, bucket: String): String {
@@ -182,6 +152,7 @@ object ArgsHelper {
 
     // https://stackoverflow.com/a/2821201/2450315
     private val envRegex = Pattern.compile("\\$([a-zA-Z_]+[a-zA-Z0-9_]*)")
+
     private fun evaluateEnvVars(text: String): String {
         val buffer = StringBuffer()
         val matcher = envRegex.matcher(text)
@@ -201,5 +172,11 @@ object ArgsHelper {
         val searchDir = Paths.get(filePath).parent
 
         return ArgsFileVisitor("glob:$filePath").walk(searchDir)
+    }
+
+    fun convertShards(shards: List<TestShard>): List<List<String>> {
+        return shards.map { shard ->
+            shard.testMethods.map { it.name }
+        }
     }
 }

--- a/test_runner/src/main/kotlin/ftl/args/ArgsHelper.kt
+++ b/test_runner/src/main/kotlin/ftl/args/ArgsHelper.kt
@@ -179,7 +179,7 @@ object ArgsHelper {
 
     fun calculateShards(filteredTests: List<String>, args: IArgs): List<List<String>> {
         val oldTestResult = GcStorage.downloadJunitXml(args) ?: JUnitTestResult(mutableListOf())
-        val shardsByTime = Shard.calculateShardsByTime(filteredTests, oldTestResult, args.testShards)
+        val shardsByTime = Shard.calculateShardsByTime(filteredTests, oldTestResult, args)
 
         return testMethodsAlwaysRun(shardsByTime.stringShards(), args)
     }

--- a/test_runner/src/main/kotlin/ftl/args/IArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IArgs.kt
@@ -15,7 +15,7 @@ interface IArgs {
     // FlankYml
     val testShards: Int
     val repeatTests: Int
-    val junitGcsPath: String
+    val smartFlankGcsPath: String
     val testTargetsAlwaysRun: List<String>
 
     // computed property

--- a/test_runner/src/main/kotlin/ftl/args/IArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IArgs.kt
@@ -15,6 +15,7 @@ interface IArgs {
     // FlankYml
     val testShards: Int
     val repeatTests: Int
+    val junitGcsPath: String
     val testTargetsAlwaysRun: List<String>
 
     // computed property

--- a/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
@@ -47,7 +47,7 @@ class IosArgs(
     private val flank = flankYml.flank
     override val testShards = flank.testShards
     override val repeatTests = flank.repeatTests
-    override val junitGcsPath = flank.junitGcsPath
+    override val smartFlankGcsPath = flank.smartFlankGcsPath
     override val testTargetsAlwaysRun = flank.testTargetsAlwaysRun
 
     private val iosFlank = iosFlankYml.flank
@@ -68,7 +68,7 @@ class IosArgs(
 
     init {
         resultsBucket = createGcsBucket(projectId, gcloud.resultsBucket)
-        createJunitBucket(projectId, flank.junitGcsPath)
+        createJunitBucket(projectId, flank.smartFlankGcsPath)
 
         if (xctestrunZip.startsWith(FtlConstants.GCS_PREFIX)) {
             assertGcsFileExists(xctestrunZip)
@@ -116,7 +116,7 @@ ${devicesToString(devices)}
     flank:
       testShards: $testShards
       repeatTests: $repeatTests
-      junitGcsPath: $junitGcsPath
+      smartFlankGcsPath: $smartFlankGcsPath
       test-targets-always-run:
 ${listToString(testTargetsAlwaysRun)}
       # iOS flank

--- a/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
@@ -61,10 +61,9 @@ class IosArgs(
             validTestMethods
         } else {
             testTargets
-        }
+        }.distinct()
 
-        // TODO: Use Shard.calculateShardsByTime
-        emptyList<List<String>>()
+        ArgsHelper.calculateShards(testsToShard, this)
     }
 
     init {

--- a/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
@@ -2,6 +2,8 @@ package ftl.args
 
 import ftl.args.ArgsHelper.assertFileExists
 import ftl.args.ArgsHelper.assertGcsFileExists
+import ftl.args.ArgsHelper.createGcsBucket
+import ftl.args.ArgsHelper.createJunitBucket
 import ftl.args.ArgsHelper.evaluateFilePath
 import ftl.args.ArgsHelper.mergeYmlMaps
 import ftl.args.ArgsHelper.validateTestMethods
@@ -29,7 +31,7 @@ class IosArgs(
 ) : IArgs {
 
     private val gcloud = gcloudYml.gcloud
-    override val resultsBucket = gcloud.resultsBucket
+    override val resultsBucket: String
     override val recordVideo = gcloud.recordVideo
     override val testTimeout = gcloud.timeout
     override val async = gcloud.async
@@ -45,6 +47,7 @@ class IosArgs(
     private val flank = flankYml.flank
     override val testShards = flank.testShards
     override val repeatTests = flank.repeatTests
+    override val junitGcsPath = flank.junitGcsPath
     override val testTargetsAlwaysRun = flank.testTargetsAlwaysRun
 
     private val iosFlank = iosFlankYml.flank
@@ -68,6 +71,9 @@ class IosArgs(
     }
 
     init {
+        resultsBucket = createGcsBucket(projectId, gcloud.resultsBucket)
+        createJunitBucket(projectId, flank.junitGcsPath)
+
         if (xctestrunZip.startsWith(FtlConstants.GCS_PREFIX)) {
             assertGcsFileExists(xctestrunZip)
         } else {
@@ -114,6 +120,7 @@ ${devicesToString(devices)}
     flank:
       testShards: $testShards
       repeatTests: $repeatTests
+      junitGcsPath: $junitGcsPath
       test-targets-always-run:
 ${listToString(testTargetsAlwaysRun)}
       # iOS flank

--- a/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/IosArgs.kt
@@ -63,11 +63,8 @@ class IosArgs(
             testTargets
         }
 
-        ArgsHelper.calculateShards(
-            testMethodsToShard = testsToShard,
-            testMethodsAlwaysRun = testTargetsAlwaysRun,
-            testShards = testShards
-            )
+        // TODO: Use Shard.calculateShardsByTime
+        emptyList<List<String>>()
     }
 
     init {

--- a/test_runner/src/main/kotlin/ftl/args/yml/FlankYml.kt
+++ b/test_runner/src/main/kotlin/ftl/args/yml/FlankYml.kt
@@ -2,6 +2,7 @@ package ftl.args.yml
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
+import ftl.config.FtlConstants.GCS_PREFIX
 import ftl.util.Utils.fatalError
 
 /** Flank specific parameters for both iOS and Android */
@@ -9,17 +10,27 @@ import ftl.util.Utils.fatalError
 class FlankYmlParams(
     val testShards: Int = 1,
     val repeatTests: Int = 1,
+    val junitGcsPath: String = "",
 
     @field:JsonProperty("test-targets-always-run")
     val testTargetsAlwaysRun: List<String> = emptyList()
 ) {
     companion object : IYmlKeys {
-        override val keys = listOf("testShards", "repeatTests", "test-targets-always-run")
+        override val keys = listOf("testShards", "repeatTests", "junitGcsPath", "test-targets-always-run")
     }
 
     init {
         if (testShards <= 0 && testShards != -1) fatalError("testShards must be >= 1 or -1")
         if (repeatTests < 1) fatalError("repeatTests must be >= 1")
+
+        if (junitGcsPath.isNotEmpty()) {
+            if (!junitGcsPath.startsWith(GCS_PREFIX)) {
+                fatalError("junitGcsPath must start with gs://")
+            }
+            if (junitGcsPath.count { it == '/' } <= 2 || !junitGcsPath.endsWith(".xml")) {
+                fatalError("junitGcsPath must be in the format gs://bucket/foo.xml")
+            }
+        }
     }
 }
 

--- a/test_runner/src/main/kotlin/ftl/args/yml/FlankYml.kt
+++ b/test_runner/src/main/kotlin/ftl/args/yml/FlankYml.kt
@@ -10,25 +10,25 @@ import ftl.util.Utils.fatalError
 class FlankYmlParams(
     val testShards: Int = 1,
     val repeatTests: Int = 1,
-    val junitGcsPath: String = "",
+    val smartFlankGcsPath: String = "",
 
     @field:JsonProperty("test-targets-always-run")
     val testTargetsAlwaysRun: List<String> = emptyList()
 ) {
     companion object : IYmlKeys {
-        override val keys = listOf("testShards", "repeatTests", "junitGcsPath", "test-targets-always-run")
+        override val keys = listOf("testShards", "repeatTests", "smartFlankGcsPath", "test-targets-always-run")
     }
 
     init {
         if (testShards <= 0 && testShards != -1) fatalError("testShards must be >= 1 or -1")
         if (repeatTests < 1) fatalError("repeatTests must be >= 1")
 
-        if (junitGcsPath.isNotEmpty()) {
-            if (!junitGcsPath.startsWith(GCS_PREFIX)) {
-                fatalError("junitGcsPath must start with gs://")
+        if (smartFlankGcsPath.isNotEmpty()) {
+            if (!smartFlankGcsPath.startsWith(GCS_PREFIX)) {
+                fatalError("smartFlankGcsPath must start with gs://")
             }
-            if (junitGcsPath.count { it == '/' } <= 2 || !junitGcsPath.endsWith(".xml")) {
-                fatalError("junitGcsPath must be in the format gs://bucket/foo.xml")
+            if (smartFlankGcsPath.count { it == '/' } <= 2 || !smartFlankGcsPath.endsWith(".xml")) {
+                fatalError("smartFlankGcsPath must be in the format gs://bucket/foo.xml")
             }
         }
     }

--- a/test_runner/src/main/kotlin/ftl/gc/GcStorage.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/GcStorage.kt
@@ -45,10 +45,10 @@ object GcStorage {
         )
 
     fun uploadJunitXml(testResult: JUnitTestResult, args: IArgs) {
-        if (args.junitGcsPath.isEmpty()) return
+        if (args.smartFlankGcsPath.isEmpty()) return
 
         // bucket/path/to/object
-        val rawPath = args.junitGcsPath.drop(GCS_PREFIX.length)
+        val rawPath = args.smartFlankGcsPath.drop(GCS_PREFIX.length)
         val bucket = rawPath.substringBefore('/')
         val name = rawPath.substringAfter('/')
 
@@ -83,7 +83,7 @@ object GcStorage {
 
     // junit xml may not exist. ignore error if it doesn't exist
     fun downloadJunitXml(args: IArgs): JUnitTestResult? {
-        val oldXmlPath = download(args.junitGcsPath, ignoreError = true)
+        val oldXmlPath = download(args.smartFlankGcsPath, ignoreError = true)
         if (oldXmlPath.isNotEmpty()) {
             return parseIosXml(Paths.get(oldXmlPath))
         }

--- a/test_runner/src/main/kotlin/ftl/ios/Xctestrun.kt
+++ b/test_runner/src/main/kotlin/ftl/ios/Xctestrun.kt
@@ -9,9 +9,13 @@ import java.nio.file.Paths
 
 object Xctestrun {
 
+    private fun String.isMetadata(): Boolean {
+        return this.contentEquals("__xctestrun_metadata__")
+    }
+
     // Parses all tests for a given target
     private fun testsForTarget(testDictionary: NSDictionary, testTarget: String, testRoot: String): List<String> {
-        if (testTarget.contentEquals("__xctestrun_metadata__")) return emptyList()
+        if (testTarget.isMetadata()) return emptyList()
         val productPaths = (testDictionary["DependentProductPaths"] as NSArray)
         for (product in productPaths.array) {
             val productString = product.toString()
@@ -93,6 +97,7 @@ object Xctestrun {
     fun rewrite(root: NSDictionary, methods: Collection<String>): ByteArray {
         val rootClone = root.clone()
         for (testTarget in rootClone.allKeys()) {
+            if (testTarget.isMetadata()) continue
             val testDictionary = (rootClone[testTarget] as NSDictionary)
             setOnlyTestIdentifiers(testDictionary, methods)
         }

--- a/test_runner/src/main/kotlin/ftl/reports/CostReport.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/CostReport.kt
@@ -12,6 +12,8 @@ import java.io.StringWriter
 /** Calculates cost based on the matrix map. Always run. */
 object CostReport : IReport {
 
+    override val extension = ".txt"
+
     private fun estimate(matrices: MatrixMap): String {
         var totalBillableVirtualMinutes = 0L
         var totalBillablePhysicalMinutes = 0L
@@ -35,7 +37,7 @@ object CostReport : IReport {
     }
 
     private fun write(matrices: MatrixMap, output: String) {
-        val reportPath = reportPath(matrices) + ".txt"
+        val reportPath = reportPath(matrices)
         reportPath.write(output)
     }
 

--- a/test_runner/src/main/kotlin/ftl/reports/HtmlErrorReport.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/HtmlErrorReport.kt
@@ -13,6 +13,8 @@ import java.nio.file.Paths
  * Outputs HTML report for Bitrise based on JUnit XML. Only run on failures.
  * */
 object HtmlErrorReport : IReport {
+    override val extension = ".html"
+
     data class Group(val key: String, val name: String, val startIndex: Int, val count: Int)
     data class Item(val key: String, val name: String, val link: String)
 
@@ -86,7 +88,7 @@ object HtmlErrorReport : IReport {
         templateData = replaceRange(templateData, findGroupRange(templateData), newGroupJson)
         templateData = replaceRange(templateData, findItemRange(templateData), newItemsJson)
 
-        val writePath = Paths.get(reportPath(matrices) + ".html")
+        val writePath = Paths.get(reportPath(matrices))
         Files.write(writePath, templateData.toByteArray())
     }
 

--- a/test_runner/src/main/kotlin/ftl/reports/JUnitReport.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/JUnitReport.kt
@@ -8,8 +8,10 @@ import ftl.util.Utils.write
 
 /** Calculates cost based on the matrix map. Always run. */
 object JUnitReport : IReport {
+    override val extension = ".xml"
+
     private fun write(matrices: MatrixMap, output: String) {
-        val reportPath = reportPath(matrices) + ".xml"
+        val reportPath = reportPath(matrices)
         reportPath.write(output)
     }
 

--- a/test_runner/src/main/kotlin/ftl/reports/MatrixResultsReport.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/MatrixResultsReport.kt
@@ -21,6 +21,7 @@ Example:
 
  **/
 object MatrixResultsReport : IReport {
+    override val extension = ".txt"
 
     private val percentFormat by lazy { DecimalFormat("#0.00") }
 
@@ -62,7 +63,7 @@ object MatrixResultsReport : IReport {
     }
 
     private fun write(matrices: MatrixMap, output: String) {
-        val reportPath = reportPath(matrices) + ".txt"
+        val reportPath = reportPath(matrices)
         reportPath.write(output)
     }
 

--- a/test_runner/src/main/kotlin/ftl/reports/util/IReport.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/util/IReport.kt
@@ -12,8 +12,10 @@ interface IReport {
         return this::class.java.simpleName
     }
 
+    val extension: String
+
     fun reportPath(matrices: MatrixMap): String {
         val path = resolveLocalRunPath(matrices)
-        return Paths.get(path, reportName()).toString()
+        return Paths.get(path, reportName() + extension).toString()
     }
 }

--- a/test_runner/src/main/kotlin/ftl/reports/util/ReportManager.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/util/ReportManager.kt
@@ -11,7 +11,6 @@ import ftl.reports.MatrixResultsReport
 import ftl.reports.xml.model.JUnitTestResult
 import ftl.reports.xml.parseAndroidXml
 import ftl.reports.xml.parseIosXml
-import ftl.reports.xml.xmlToString
 import ftl.util.ArtifactRegex
 import ftl.util.resolveLocalRunPath
 import java.io.File
@@ -100,11 +99,10 @@ object ReportManager {
     private fun processJunitXml(newTestResult: JUnitTestResult?, args: IArgs) {
         if (newTestResult == null) return
 
-        val oldXmlPath = GcStorage.downloadJunitXml(args)
-        val oldTestResult = if (oldXmlPath.isNotEmpty()) parseIosXml(oldXmlPath) else null
+        val oldTestResult = GcStorage.downloadJunitXml(args)
 
         newTestResult.mergeTestTimes(oldTestResult)
 
-        GcStorage.uploadJunitXml(newTestResult.xmlToString(), args)
+        GcStorage.uploadJunitXml(newTestResult, args)
     }
 }

--- a/test_runner/src/main/kotlin/ftl/reports/util/ReportManager.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/util/ReportManager.kt
@@ -2,6 +2,7 @@ package ftl.reports.util
 
 import ftl.args.IArgs
 import ftl.args.IosArgs
+import ftl.gc.GcStorage
 import ftl.json.MatrixMap
 import ftl.reports.CostReport
 import ftl.reports.HtmlErrorReport
@@ -10,6 +11,7 @@ import ftl.reports.MatrixResultsReport
 import ftl.reports.xml.model.JUnitTestResult
 import ftl.reports.xml.parseAndroidXml
 import ftl.reports.xml.parseIosXml
+import ftl.reports.xml.xmlToString
 import ftl.util.ArtifactRegex
 import ftl.util.resolveLocalRunPath
 import java.io.File
@@ -62,14 +64,18 @@ object ReportManager {
         return mergedXml
     }
 
-    /** Returns true if there were no test failures */
-    fun generate(matrices: MatrixMap, args: IArgs): Int {
+    private fun parseTestSuite(matrices: MatrixMap, args: IArgs): JUnitTestResult? {
         val iosXml = args is IosArgs
-        val testSuite = if (iosXml) {
+        return if (iosXml) {
             processXml(matrices, ::parseIosXml)
         } else {
             processXml(matrices, ::parseAndroidXml)
         }
+    }
+
+    /** Returns true if there were no test failures */
+    fun generate(matrices: MatrixMap, args: IArgs): Int {
+        val testSuite = parseTestSuite(matrices, args)
         val testSuccessful = matrices.allSuccessful()
 
         listOf(
@@ -79,14 +85,26 @@ object ReportManager {
             it.run(matrices, testSuite, printToStdout = true)
         }
 
-        JUnitReport.run(matrices, testSuite)
-
         if (!testSuccessful) {
             listOf(
                 HtmlErrorReport
             ).map { it.run(matrices, testSuite) }
         }
 
+        JUnitReport.run(matrices, testSuite)
+        processJunitXml(testSuite, args)
+
         return matrices.exitCode()
+    }
+
+    private fun processJunitXml(newTestResult: JUnitTestResult?, args: IArgs) {
+        if (newTestResult == null) return
+
+        val oldXmlPath = GcStorage.downloadJunitXml(args)
+        val oldTestResult = if (oldXmlPath.isNotEmpty()) parseIosXml(oldXmlPath) else null
+
+        newTestResult.mergeTestTimes(oldTestResult)
+
+        GcStorage.uploadJunitXml(newTestResult.xmlToString(), args)
     }
 }

--- a/test_runner/src/main/kotlin/ftl/reports/xml/model/JUnitTestCase.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/xml/model/JUnitTestCase.kt
@@ -24,11 +24,11 @@ data class JUnitTestCase(
     // JUnit XML allows arbitrary amounts of failure/error tags
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JacksonXmlProperty(localName = "failure")
-    val failures: List<String>?,
+    val failures: List<String>? = null,
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JacksonXmlProperty(localName = "error")
-    val errors: List<String>?,
+    val errors: List<String>? = null,
 
     @JsonInclude(JsonInclude.Include.CUSTOM, valueFilter = FilterNotNull::class)
     val skipped: String? = "absent" // used by FilterNotNull to filter out absent `skipped` values
@@ -39,6 +39,14 @@ data class JUnitTestCase(
 
     fun failed(): Boolean {
         return failures?.isNotEmpty() == true || errors?.isNotEmpty() == true
+    }
+
+    fun skipped(): Boolean {
+        return skipped == null
+    }
+
+    fun successful(): Boolean {
+        return failed().not().and(skipped().not())
     }
 
     fun stackTrace(): String {

--- a/test_runner/src/main/kotlin/ftl/reports/xml/model/JUnitTestResult.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/xml/model/JUnitTestResult.kt
@@ -11,6 +11,22 @@ data class JUnitTestResult(
     @JacksonXmlProperty(localName = "testsuite")
     var testsuites: MutableList<JUnitTestSuite>?
 ) {
+    fun mergeTestTimes(other: JUnitTestResult?): JUnitTestResult {
+        if (other == null) return this
+        if (this.testsuites == null) this.testsuites = mutableListOf()
+
+        // newTestResult.mergeTestTimes(oldTestResult)
+        //
+        // for each new JUnitTestSuite, check if it exists on old
+        // if JUnitTestSuite exists on both then merge test times
+        this.testsuites?.forEach { testSuite ->
+            val oldSuite = other.testsuites?.firstOrNull { it.name == testSuite.name }
+            if (oldSuite != null) testSuite.mergeTestTimes(oldSuite)
+        }
+
+        return this
+    }
+
     fun merge(other: JUnitTestResult?): JUnitTestResult {
         if (other == null) return this
         if (this.testsuites == null) this.testsuites = mutableListOf()

--- a/test_runner/src/main/kotlin/ftl/run/GenericTestRunner.kt
+++ b/test_runner/src/main/kotlin/ftl/run/GenericTestRunner.kt
@@ -60,8 +60,7 @@ object GenericTestRunner {
 
         val result = StringBuilder()
         result.appendln(
-            "  $testsCount test${s(testsCount)} / $shardCount shard${s(shardCount)} = " +
-                "$testsPerShard test${s(testsPerShard)} per shard"
+            "  $testsCount test${s(testsCount)} / $shardCount shard${s(shardCount)}"
         )
 
         if (runCount > 1) {

--- a/test_runner/src/main/kotlin/ftl/run/GenericTestRunner.kt
+++ b/test_runner/src/main/kotlin/ftl/run/GenericTestRunner.kt
@@ -55,7 +55,6 @@ object GenericTestRunner {
     fun beforeRunMessage(args: IArgs): String {
         val runCount = args.repeatTests
         val shardCount = args.testShardChunks.size
-        val testsPerShard = args.testShardChunks.first().size
         val testsCount = args.testShardChunks.sumBy { it.size }
 
         val result = StringBuilder()

--- a/test_runner/src/main/kotlin/ftl/shard/Shard.kt
+++ b/test_runner/src/main/kotlin/ftl/shard/Shard.kt
@@ -79,8 +79,8 @@ object Shard {
 
         val allTests = runningTests.size
         val cacheHit = allTests - cacheMiss
-        val cachePercent = cacheHit / allTests * 100
-        println("  Smart Flank cache hit: $cachePercent% ($cacheHit / $allTests)")
+        val cachePercent = cacheHit.toDouble() / allTests * 100.0
+        println("  Smart Flank cache hit: ${cachePercent.roundToInt()}% ($cacheHit / $allTests)")
         println("  Shard times: " + shards.map { it.time.roundToInt() }.joinToString(", ") + "\n")
 
         return shards

--- a/test_runner/src/main/kotlin/ftl/shard/Shard.kt
+++ b/test_runner/src/main/kotlin/ftl/shard/Shard.kt
@@ -1,0 +1,64 @@
+package ftl.shard
+
+data class TestMethod(
+    val name: String,
+    val time: Double
+)
+
+data class TestShard(
+    val time: Double,
+    val testMethods: MutableList<TestMethod>
+)
+
+data class TestShards(
+    val shards: MutableList<TestShard> = mutableListOf()
+)
+
+object Shard {
+
+    /**
+     * Build shard by removing remaining methods that total to targetShardDuration
+     * At least one method per shard will always be returned, regardless of targetShardDuration.
+     *
+     * remainingMethods must be sorted in order of fastest execution time to slowest.
+     * remainingMethods.sortBy { it.time }
+     *
+     * Based on createConfigurableShard from Flank Java
+     * https://github.com/TestArmada/flank/blob/ceda6d2c3d9eb2a366f19b826e04289cd24bddf3/Flank/src/main/java/com/walmart/otto/shards/ShardCreator.java#L99
+     */
+    fun build(remainingMethods: MutableList<TestMethod>, targetShardDuration: Double): TestShard {
+        var timeBudget = targetShardDuration
+        var shardTime = 0.0
+
+        val testMethods = remainingMethods.iterator()
+        val shardTests = mutableListOf<TestMethod>()
+
+        while (testMethods.hasNext()) {
+            val test = testMethods.next()
+            val testWithinBudget = timeBudget - test.time >= 0
+
+            if (testWithinBudget) {
+                timeBudget -= test.time
+
+                shardTime += test.time
+                shardTests.add(test)
+                testMethods.remove()
+
+                continue
+            }
+
+            val noTestsAdded = timeBudget == targetShardDuration
+            val testOverBudget = test.time >= timeBudget
+
+            if (noTestsAdded && testOverBudget) {
+                // Always add at least 1 test per shard regardless of budget
+                shardTime += test.time
+                shardTests.add(test)
+                testMethods.remove()
+
+                return TestShard(shardTime, shardTests)
+            }
+        }
+        return TestShard(shardTime, shardTests)
+    }
+}

--- a/test_runner/src/main/kotlin/ftl/shard/Shard.kt
+++ b/test_runner/src/main/kotlin/ftl/shard/Shard.kt
@@ -1,6 +1,7 @@
 package ftl.shard
 
 import ftl.reports.xml.model.JUnitTestResult
+import kotlin.math.roundToInt
 
 data class TestMethod(
     val name: String,
@@ -80,7 +81,7 @@ object Shard {
         val cacheHit = allTests - cacheMiss
         val cachePercent = cacheHit / allTests * 100
         println("  Smart Flank cache hit: $cachePercent% ($cacheHit / $allTests)")
-        println("  Shard times: " + shards.map { it.time }.joinToString(", ") + "\n")
+        println("  Shard times: " + shards.map { it.time.roundToInt() }.joinToString(", ") + "\n")
 
         return shards
     }

--- a/test_runner/src/main/kotlin/ftl/shard/Shard.kt
+++ b/test_runner/src/main/kotlin/ftl/shard/Shard.kt
@@ -12,6 +12,15 @@ data class TestShard(
     val testMethods: MutableList<TestMethod>
 )
 
+/** List of shards containing test names as a string. */
+typealias StringShards = MutableList<MutableList<String>>
+
+fun List<TestShard>.stringShards(): StringShards {
+    return this.map { shard ->
+        shard.testMethods.map { it.name }.toMutableList()
+    }.toMutableList()
+}
+
 object Shard {
 
     // take in the XML with timing info then return list of shards

--- a/test_runner/src/main/kotlin/ftl/shard/Shard.kt
+++ b/test_runner/src/main/kotlin/ftl/shard/Shard.kt
@@ -1,64 +1,61 @@
 package ftl.shard
 
+import ftl.reports.xml.model.JUnitTestResult
+
 data class TestMethod(
     val name: String,
     val time: Double
 )
 
 data class TestShard(
-    val time: Double,
+    var time: Double,
     val testMethods: MutableList<TestMethod>
-)
-
-data class TestShards(
-    val shards: MutableList<TestShard> = mutableListOf()
 )
 
 object Shard {
 
-    /**
-     * Build shard by removing remaining methods that total to targetShardDuration
-     * At least one method per shard will always be returned, regardless of targetShardDuration.
-     *
-     * remainingMethods must be sorted in order of fastest execution time to slowest.
-     * remainingMethods.sortBy { it.time }
-     *
-     * Based on createConfigurableShard from Flank Java
-     * https://github.com/TestArmada/flank/blob/ceda6d2c3d9eb2a366f19b826e04289cd24bddf3/Flank/src/main/java/com/walmart/otto/shards/ShardCreator.java#L99
-     */
-    fun build(remainingMethods: MutableList<TestMethod>, targetShardDuration: Double): TestShard {
-        var timeBudget = targetShardDuration
-        var shardTime = 0.0
+    // take in the XML with timing info then return list of shards
+    fun calculateShardsByTime(runningTests: List<String>, testResult: JUnitTestResult, maxShards: Int): List<TestShard> {
 
-        val testMethods = remainingMethods.iterator()
-        val shardTests = mutableListOf<TestMethod>()
+        val junitMap = mutableMapOf<String, Double>()
 
-        while (testMethods.hasNext()) {
-            val test = testMethods.next()
-            val testWithinBudget = timeBudget - test.time >= 0
-
-            if (testWithinBudget) {
-                timeBudget -= test.time
-
-                shardTime += test.time
-                shardTests.add(test)
-                testMethods.remove()
-
-                continue
-            }
-
-            val noTestsAdded = timeBudget == targetShardDuration
-            val testOverBudget = test.time >= timeBudget
-
-            if (noTestsAdded && testOverBudget) {
-                // Always add at least 1 test per shard regardless of budget
-                shardTime += test.time
-                shardTests.add(test)
-                testMethods.remove()
-
-                return TestShard(shardTime, shardTests)
+        // Create a map with information from previous junit run
+        testResult.testsuites?.forEach { testsuite ->
+            testsuite.testcases?.forEach { testcase ->
+                val key = "${testsuite.name}${testcase.classname}#${testcase.name}".trim()
+                junitMap[key] = testcase.time.toDouble()
             }
         }
-        return TestShard(shardTime, shardTests)
+
+        val testcases = mutableListOf<TestMethod>()
+        runningTests.forEach {
+            // junitMap doesn't include `class `, we remove it to search in the map
+            val key = it.replaceFirst("class ", "")
+            val time = junitMap[key] ?: 10.0
+            testcases.add(TestMethod(it, time))
+        }
+
+        val testCount = testcases.size
+
+        // If maxShards is infinite or we have more shards than tests, let's match it
+        val shardsCount = if (maxShards == -1 || maxShards > testCount) testCount else maxShards
+
+        // Create the list of shards we will return
+        var shards = List(shardsCount) { TestShard(0.0, mutableListOf()) }
+
+        // We want to iterate over testcase going from slowest to fastest
+        testcases.sortByDescending { it.time }
+
+        testcases.forEach { testMethod ->
+            val shard = shards.first()
+
+            shard.testMethods.add(testMethod)
+            shard.time += testMethod.time
+
+            // Sort the shards to keep the most empty shard first
+            shards = shards.sortedBy { it.time }
+        }
+
+        return shards
     }
 }

--- a/test_runner/src/main/kotlin/ftl/shard/Shard.kt
+++ b/test_runner/src/main/kotlin/ftl/shard/Shard.kt
@@ -51,7 +51,7 @@ object Shard {
             if (previousTime == null) {
                 cacheMiss += 1
             }
-            
+
             testcases.add(TestMethod(it, time))
         }
 

--- a/test_runner/src/main/kotlin/ftl/shard/Shard.kt
+++ b/test_runner/src/main/kotlin/ftl/shard/Shard.kt
@@ -36,7 +36,7 @@ object Shard {
         // Create a map with information from previous junit run
         testResult.testsuites?.forEach { testsuite ->
             testsuite.testcases?.forEach { testcase ->
-                val key = "${testsuite.name}${testcase.classname}#${testcase.name}".trim()
+                val key = "${testcase.classname}#${testcase.name.replaceFirst("()", "")}".trim()
                 junitMap[key] = testcase.time.toDouble()
             }
         }
@@ -45,7 +45,7 @@ object Shard {
         val testcases = mutableListOf<TestMethod>()
         runningTests.forEach {
             // junitMap doesn't include `class `, we remove it to search in the map
-            val key = it.replaceFirst("class ", "")
+            val key = it.replaceFirst("class ", "").replaceFirst("/", "#")
             val previousTime = junitMap[key]
             val time = previousTime ?: 10.0
 

--- a/test_runner/src/test/kotlin/ftl/args/AndroidArgsFileTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/AndroidArgsFileTest.kt
@@ -143,8 +143,8 @@ class AndroidArgsFileTest {
         val config = configWithTestMethods(155, testShards = 40)
         with(config) {
             assert(testShards, 40)
-            assert(testShardChunks.size, 39)
-            assert(testShardChunks.first().size, 4)
+            assert(testShardChunks.size, 40)
+            assert(testShardChunks.first().size, 3)
         }
     }
 

--- a/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
@@ -202,6 +202,7 @@ AndroidArgs
     flank:
       testShards: 7
       repeatTests: 8
+      junitGcsPath:${' '}
       test-targets-always-run:
         - class example.Test#grantPermission
         - class example.Test#grantPermission2

--- a/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
@@ -202,7 +202,7 @@ AndroidArgs
     flank:
       testShards: 7
       repeatTests: 8
-      junitGcsPath:${' '}
+      smartFlankGcsPath:${' '}
       test-targets-always-run:
         - class example.Test#grantPermission
         - class example.Test#grantPermission2

--- a/test_runner/src/test/kotlin/ftl/args/ArgsHelperTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/ArgsHelperTest.kt
@@ -4,7 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import ftl.args.ArgsHelper.assertFileExists
 import ftl.args.ArgsHelper.assertGcsFileExists
 import ftl.args.ArgsHelper.calculateShards
-import ftl.args.ArgsHelper.getGcsBucket
+import ftl.args.ArgsHelper.createGcsBucket
 import ftl.args.ArgsHelper.mergeYmlMaps
 import ftl.args.ArgsHelper.validateTestMethods
 import ftl.args.yml.GcloudYml
@@ -158,8 +158,8 @@ class ArgsHelperTest {
     }
 
     @Test
-    fun getGcsBucket_succeeds() {
-        getGcsBucket("123", "results_bucket")
+    fun createGcsBucket_succeeds() {
+        createGcsBucket("123", "results_bucket")
     }
 
     @Test

--- a/test_runner/src/test/kotlin/ftl/args/ArgsHelperTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/ArgsHelperTest.kt
@@ -3,7 +3,6 @@ package ftl.args
 import com.google.common.truth.Truth.assertThat
 import ftl.args.ArgsHelper.assertFileExists
 import ftl.args.ArgsHelper.assertGcsFileExists
-import ftl.args.ArgsHelper.convertShards
 import ftl.args.ArgsHelper.createGcsBucket
 import ftl.args.ArgsHelper.mergeYmlMaps
 import ftl.args.ArgsHelper.validateTestMethods
@@ -11,6 +10,7 @@ import ftl.args.yml.GcloudYml
 import ftl.args.yml.IosGcloudYml
 import ftl.shard.TestMethod
 import ftl.shard.TestShard
+import ftl.shard.stringShards
 import ftl.test.util.FlankTestRunner
 import ftl.test.util.TestHelper.absolutePath
 import org.junit.Rule
@@ -165,20 +165,22 @@ class ArgsHelperTest {
     fun evaluateInvalidFilePath() {
         val testApkPath = "~/flank_test_app/invalid_path/app-debug-*.xctestrun"
         ArgsHelper.evaluateFilePath(testApkPath)
-        fun convertShardsTest() {
-            val shards = listOf(
-                TestShard(3.0, mutableListOf(TestMethod("a", 1.0), TestMethod("b", 2.0))),
-                TestShard(4.0, mutableListOf(TestMethod("c", 4.0))),
-                TestShard(5.0, mutableListOf(TestMethod("d", 2.0), TestMethod("e", 3.0)))
-            )
+    }
 
-            val expected = listOf(
-                listOf("a", "b"),
-                listOf("c"),
-                listOf("d", "e")
-            )
+    @Test
+    fun stringShardsTest() {
+        val shards = listOf(
+            TestShard(3.0, mutableListOf(TestMethod("a", 1.0), TestMethod("b", 2.0))),
+            TestShard(4.0, mutableListOf(TestMethod("c", 4.0))),
+            TestShard(5.0, mutableListOf(TestMethod("d", 2.0), TestMethod("e", 3.0)))
+        )
 
-            assertThat(convertShards(shards)).isEqualTo(expected)
-        }
+        val expected = listOf(
+            listOf("a", "b"),
+            listOf("c"),
+            listOf("d", "e")
+        )
+
+        assertThat(shards.stringShards()).isEqualTo(expected)
     }
 }

--- a/test_runner/src/test/kotlin/ftl/args/IosArgsFileTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/IosArgsFileTest.kt
@@ -72,14 +72,14 @@ class IosArgsFileTest {
             "EarlGreyExampleMixedTests/testGrantCameraPermission",
             "EarlGreyExampleMixedTests/testGrantMicrophonePermission",
             "EarlGreyExampleMixedTests/testBasicSelection1",
-            "EarlGreyExampleMixedTests/testBasicSelection2"
+            "EarlGreyExampleMixedTests/testBasicSelection4"
         )
 
         val chunk1 = arrayListOf(
             "EarlGreyExampleMixedTests/testGrantCameraPermission",
             "EarlGreyExampleMixedTests/testGrantMicrophonePermission",
-            "EarlGreyExampleMixedTests/testBasicSelection3",
-            "EarlGreyExampleMixedTests/testBasicSelection4"
+            "EarlGreyExampleMixedTests/testBasicSelection2",
+            "EarlGreyExampleMixedTests/testBasicSelection3"
         )
 
         val testShardChunks = config.testShardChunks

--- a/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
@@ -150,6 +150,7 @@ IosArgs
     flank:
       testShards: 7
       repeatTests: 8
+      junitGcsPath:${' '}
       test-targets-always-run:
         - a/testGrantPermissions
         - a/testGrantPermissions2

--- a/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/IosArgsTest.kt
@@ -150,7 +150,7 @@ IosArgs
     flank:
       testShards: 7
       repeatTests: 8
-      junitGcsPath:${' '}
+      smartFlankGcsPath:${' '}
       test-targets-always-run:
         - a/testGrantPermissions
         - a/testGrantPermissions2

--- a/test_runner/src/test/kotlin/ftl/fixtures/android_catalog.json
+++ b/test_runner/src/test/kotlin/ftl/fixtures/android_catalog.json
@@ -3,6 +3,7 @@
     "brand" : "OnePlus",
     "codename" : "A0001",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "A0001",
     "manufacturer" : "OnePlus",
     "name" : "OnePlus One",
@@ -10,12 +11,12 @@
     "screenX" : 1080,
     "screenY" : 1920,
     "supportedAbis" : [ "armeabi-v7a", "armeabi" ],
-    "supportedVersionIds" : [ "22" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "22" ]
   }, {
     "brand" : "Sony",
     "codename" : "D6503",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "D6503",
     "manufacturer" : "Sony",
     "name" : "Xperia Z2",
@@ -23,12 +24,12 @@
     "screenX" : 1080,
     "screenY" : 1920,
     "supportedAbis" : [ "armeabi-v7a", "armeabi" ],
-    "supportedVersionIds" : [ "21" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "21" ]
   }, {
     "brand" : "Sony",
     "codename" : "D6603",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "D6603",
     "manufacturer" : "Sony",
     "name" : "Xperia Z3",
@@ -37,11 +38,12 @@
     "screenY" : 1920,
     "supportedAbis" : [ "armeabi-v7a", "armeabi" ],
     "supportedVersionIds" : [ "21" ],
-    "formFactor" : "PHONE"
+    "tags" : [ "deprecated" ]
   }, {
     "brand" : "Sony",
     "codename" : "E5803",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "E5803",
     "manufacturer" : "Sony",
     "name" : "Xperia Z5 Compact",
@@ -49,12 +51,12 @@
     "screenX" : 720,
     "screenY" : 1280,
     "supportedAbis" : [ "arm64-v8a", "armeabi-v7a", "armeabi" ],
-    "tags" : [ "deprecated" ],
-    "formFactor" : "PHONE"
+    "tags" : [ "deprecated" ]
   }, {
     "brand" : "Sony",
     "codename" : "F5121",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "F5121",
     "manufacturer" : "Sony",
     "name" : "Sony Xperia X",
@@ -62,12 +64,12 @@
     "screenX" : 1080,
     "screenY" : 1920,
     "supportedAbis" : [ "arm64-v8a", "armeabi-v7a", "armeabi" ],
-    "tags" : [ "deprecated" ],
-    "formFactor" : "PHONE"
+    "tags" : [ "deprecated" ]
   }, {
     "brand" : "Sony",
     "codename" : "G8142",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "G8142",
     "manufacturer" : "Sony",
     "name" : "Sony XPERIA XZ Premium",
@@ -75,12 +77,12 @@
     "screenX" : 1080,
     "screenY" : 1920,
     "supportedAbis" : [ "arm64-v8a", "armeabi-v7a", "armeabi" ],
-    "supportedVersionIds" : [ "25" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "25" ]
   }, {
     "brand" : "Sony",
     "codename" : "G8441",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "G8441",
     "manufacturer" : "Sony",
     "name" : "Xperia XZ1 Compact",
@@ -88,12 +90,12 @@
     "screenX" : 720,
     "screenY" : 1280,
     "supportedAbis" : [ "arm64-v8a", "armeabi-v7a", "armeabi" ],
-    "supportedVersionIds" : [ "26" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "26" ]
   }, {
     "brand" : "HUAWEI",
     "codename" : "HWMHA",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "HWMHA",
     "manufacturer" : "Huawei",
     "name" : "Huawei Mate 9",
@@ -101,12 +103,12 @@
     "screenX" : 1080,
     "screenY" : 1920,
     "supportedAbis" : [ "arm64-v8a", "armeabi-v7a", "armeabi" ],
-    "supportedVersionIds" : [ "24" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "24" ]
   }, {
     "brand" : "Google",
     "codename" : "Nexus10",
     "form" : "VIRTUAL",
+    "formFactor" : "TABLET",
     "id" : "Nexus10",
     "manufacturer" : "Samsung",
     "name" : "Nexus 10",
@@ -114,12 +116,12 @@
     "screenX" : 1600,
     "screenY" : 2560,
     "supportedAbis" : [ "x86" ],
-    "supportedVersionIds" : [ "19", "21", "22" ],
-    "formFactor" : "TABLET"
+    "supportedVersionIds" : [ "19", "21", "22" ]
   }, {
     "brand" : "Google",
     "codename" : "Nexus4",
     "form" : "VIRTUAL",
+    "formFactor" : "PHONE",
     "id" : "Nexus4",
     "manufacturer" : "LG",
     "name" : "Nexus 4",
@@ -127,12 +129,12 @@
     "screenX" : 768,
     "screenY" : 1280,
     "supportedAbis" : [ "x86" ],
-    "supportedVersionIds" : [ "19", "21", "22" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "19", "21", "22" ]
   }, {
     "brand" : "Google",
     "codename" : "Nexus5",
     "form" : "VIRTUAL",
+    "formFactor" : "PHONE",
     "id" : "Nexus5",
     "manufacturer" : "LG",
     "name" : "Nexus 5",
@@ -140,12 +142,12 @@
     "screenX" : 1080,
     "screenY" : 1920,
     "supportedAbis" : [ "x86", "23:armeabi", "23:armeabi-v7a" ],
-    "supportedVersionIds" : [ "19", "21", "22", "23" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "19", "21", "22", "23" ]
   }, {
     "brand" : "Google",
     "codename" : "Nexus5X",
     "form" : "VIRTUAL",
+    "formFactor" : "PHONE",
     "id" : "Nexus5X",
     "manufacturer" : "LG",
     "name" : "Nexus 5X",
@@ -153,12 +155,12 @@
     "screenX" : 1080,
     "screenY" : 1920,
     "supportedAbis" : [ "x86", "23:armeabi", "23:armeabi-v7a", "24:armeabi", "24:armeabi-v7a", "25:armeabi", "25:armeabi-v7a", "26:armeabi", "26:armeabi-v7a" ],
-    "supportedVersionIds" : [ "23", "24", "25", "26" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "23", "24", "25", "26" ]
   }, {
     "brand" : "Google",
     "codename" : "Nexus6",
     "form" : "VIRTUAL",
+    "formFactor" : "PHONE",
     "id" : "Nexus6",
     "manufacturer" : "Motorola",
     "name" : "Nexus 6",
@@ -166,12 +168,12 @@
     "screenX" : 1440,
     "screenY" : 2560,
     "supportedAbis" : [ "x86", "23:armeabi", "23:armeabi-v7a", "24:armeabi", "24:armeabi-v7a", "25:armeabi", "25:armeabi-v7a" ],
-    "supportedVersionIds" : [ "21", "22", "23", "24", "25" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "21", "22", "23", "24", "25" ]
   }, {
     "brand" : "Google",
     "codename" : "Nexus6P",
     "form" : "VIRTUAL",
+    "formFactor" : "PHONE",
     "id" : "Nexus6P",
     "manufacturer" : "Google",
     "name" : "Nexus 6P",
@@ -179,12 +181,12 @@
     "screenX" : 1440,
     "screenY" : 2560,
     "supportedAbis" : [ "x86", "23:armeabi", "23:armeabi-v7a", "24:armeabi", "24:armeabi-v7a", "25:armeabi", "25:armeabi-v7a", "26:armeabi", "26:armeabi-v7a", "27:armeabi", "27:armeabi-v7a" ],
-    "supportedVersionIds" : [ "23", "24", "25", "26", "27" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "23", "24", "25", "26", "27" ]
   }, {
     "brand" : "Google",
     "codename" : "Nexus7",
     "form" : "VIRTUAL",
+    "formFactor" : "TABLET",
     "id" : "Nexus7",
     "manufacturer" : "Asus",
     "name" : "Nexus 7 (2012)",
@@ -192,12 +194,12 @@
     "screenX" : 800,
     "screenY" : 1280,
     "supportedAbis" : [ "x86" ],
-    "supportedVersionIds" : [ "19", "21", "22" ],
-    "formFactor" : "TABLET"
+    "supportedVersionIds" : [ "19", "21", "22" ]
   }, {
     "brand" : "Generic",
     "codename" : "Nexus7_clone_16_9",
     "form" : "VIRTUAL",
+    "formFactor" : "TABLET",
     "id" : "Nexus7_clone_16_9",
     "manufacturer" : "Generic",
     "name" : "Nexus7 clone, DVD 16:9 aspect ratio",
@@ -206,12 +208,12 @@
     "screenY" : 1280,
     "supportedAbis" : [ "x86", "23:armeabi", "23:armeabi-v7a", "24:armeabi", "24:armeabi-v7a", "25:armeabi", "25:armeabi-v7a", "26:armeabi", "26:armeabi-v7a" ],
     "supportedVersionIds" : [ "23", "24", "25", "26" ],
-    "tags" : [ "beta" ],
-    "formFactor" : "TABLET"
+    "tags" : [ "beta" ]
   }, {
     "brand" : "Google",
     "codename" : "Nexus9",
     "form" : "VIRTUAL",
+    "formFactor" : "TABLET",
     "id" : "Nexus9",
     "manufacturer" : "HTC",
     "name" : "Nexus 9",
@@ -219,12 +221,12 @@
     "screenX" : 1536,
     "screenY" : 2048,
     "supportedAbis" : [ "x86", "23:armeabi", "23:armeabi-v7a", "24:armeabi", "24:armeabi-v7a", "25:armeabi", "25:armeabi-v7a" ],
-    "supportedVersionIds" : [ "21", "22", "23", "24", "25" ],
-    "formFactor" : "TABLET"
+    "supportedVersionIds" : [ "21", "22", "23", "24", "25" ]
   }, {
     "brand" : "Generic",
     "codename" : "NexusLowRes",
     "form" : "VIRTUAL",
+    "formFactor" : "PHONE",
     "id" : "NexusLowRes",
     "manufacturer" : "Generic",
     "name" : "Low-resolution MDPI phone",
@@ -232,12 +234,12 @@
     "screenX" : 360,
     "screenY" : 640,
     "supportedAbis" : [ "x86", "23:armeabi", "23:armeabi-v7a", "24:armeabi", "24:armeabi-v7a", "25:armeabi", "25:armeabi-v7a", "26:armeabi", "26:armeabi-v7a", "27:armeabi", "27:armeabi-v7a", "28:armeabi", "28:armeabi-v7a" ],
-    "supportedVersionIds" : [ "23", "24", "25", "26", "27", "28" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "23", "24", "25", "26", "27", "28" ]
   }, {
     "brand" : "OnePlus",
     "codename" : "OnePlus5",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "OnePlus5",
     "manufacturer" : "OnePlus",
     "name" : "OnePlus 5",
@@ -245,26 +247,25 @@
     "screenX" : 1080,
     "screenY" : 1920,
     "supportedAbis" : [ "arm64-v8a", "armeabi-v7a", "armeabi" ],
-    "supportedVersionIds" : [ "26" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "26" ]
   }, {
     "brand" : "Google",
     "codename" : "Pixel2",
     "form" : "VIRTUAL",
+    "formFactor" : "PHONE",
     "id" : "Pixel2",
-    "manufacturer" : "HTC",
+    "manufacturer" : "Google",
     "name" : "Pixel 2",
     "screenDensity" : 441,
     "screenX" : 1080,
     "screenY" : 1920,
     "supportedAbis" : [ "x86", "26:armeabi", "26:armeabi-v7a", "27:armeabi", "27:armeabi-v7a", "28:armeabi", "28:armeabi-v7a" ],
-    "supportedVersionIds" : [ "26", "27", "28" ],
-    "tags" : [ "beta" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "26", "27", "28" ]
   }, {
     "brand" : "DOCOMO",
     "codename" : "SH-04H",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "SH-04H",
     "manufacturer" : "SHARP",
     "name" : "SH-04H",
@@ -273,12 +274,12 @@
     "screenY" : 1920,
     "supportedAbis" : [ "arm64-v8a", "armeabi-v7a", "armeabi" ],
     "supportedVersionIds" : [ "23" ],
-    "tags" : [ "deprecated" ],
-    "formFactor" : "PHONE"
+    "tags" : [ "deprecated" ]
   }, {
     "brand" : "samsung",
     "codename" : "a5y17lte",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "a5y17lte",
     "manufacturer" : "Samsung",
     "name" : "Galaxy A5 2017",
@@ -286,12 +287,12 @@
     "screenX" : 1080,
     "screenY" : 1920,
     "supportedAbis" : [ "arm64-v8a", "armeabi-v7a", "armeabi" ],
-    "supportedVersionIds" : [ "24" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "24" ]
   }, {
     "brand" : "Motorola",
     "codename" : "athene",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "athene",
     "manufacturer" : "Motorola",
     "name" : "Moto G4 Plus",
@@ -299,12 +300,12 @@
     "screenX" : 1080,
     "screenY" : 1920,
     "supportedAbis" : [ "armeabi-v7a", "armeabi" ],
-    "supportedVersionIds" : [ "23" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "23" ]
   }, {
     "brand" : "Motorola",
     "codename" : "athene_f",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "athene_f",
     "manufacturer" : "Motorola",
     "name" : "Moto G4",
@@ -312,12 +313,12 @@
     "screenX" : 1080,
     "screenY" : 1920,
     "supportedAbis" : [ "armeabi-v7a", "armeabi" ],
-    "supportedVersionIds" : [ "23" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "23" ]
   }, {
     "brand" : "razer",
     "codename" : "cheryl",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "cheryl",
     "manufacturer" : "Razer",
     "name" : "Razer Phone",
@@ -325,12 +326,12 @@
     "screenX" : 1440,
     "screenY" : 2560,
     "supportedAbis" : [ "arm64-v8a", "armeabi-v7a", "armeabi" ],
-    "supportedVersionIds" : [ "25" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "25" ]
   }, {
     "brand" : "Motorola",
     "codename" : "condor_umts",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "condor_umts",
     "manufacturer" : "Motorola",
     "name" : "Moto E",
@@ -338,12 +339,12 @@
     "screenX" : 540,
     "screenY" : 960,
     "supportedAbis" : [ "armeabi-v7a", "armeabi" ],
-    "tags" : [ "deprecated" ],
-    "formFactor" : "PHONE"
+    "tags" : [ "deprecated" ]
   }, {
     "brand" : "Motorola",
     "codename" : "falcon_umts",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "falcon_umts",
     "manufacturer" : "Motorola",
     "name" : "Moto G (1st Gen)",
@@ -351,12 +352,12 @@
     "screenX" : 720,
     "screenY" : 1280,
     "supportedAbis" : [ "armeabi-v7a", "armeabi" ],
-    "tags" : [ "deprecated" ],
-    "formFactor" : "PHONE"
+    "tags" : [ "deprecated" ]
   }, {
     "brand" : "ASUS",
     "codename" : "flo",
     "form" : "PHYSICAL",
+    "formFactor" : "TABLET",
     "id" : "flo",
     "manufacturer" : "Asus",
     "name" : "Nexus 7 (2013)",
@@ -364,12 +365,12 @@
     "screenX" : 1200,
     "screenY" : 1920,
     "supportedAbis" : [ "armeabi-v7a", "armeabi" ],
-    "supportedVersionIds" : [ "19", "21" ],
-    "formFactor" : "TABLET"
+    "supportedVersionIds" : [ "19", "21" ]
   }, {
     "brand" : "LG",
     "codename" : "g3",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "g3",
     "manufacturer" : "LG",
     "name" : "LG G3",
@@ -377,12 +378,12 @@
     "screenX" : 1440,
     "screenY" : 2560,
     "supportedAbis" : [ "armeabi-v7a", "armeabi" ],
-    "supportedVersionIds" : [ "19" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "19" ]
   }, {
     "brand" : "Samsung",
     "codename" : "grandpplte",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "grandpplte",
     "manufacturer" : "Samsung",
     "name" : "Galaxy J2 Prime SM-G532M",
@@ -390,12 +391,25 @@
     "screenX" : 540,
     "screenY" : 960,
     "supportedAbis" : [ "armeabi-v7a", "armeabi" ],
-    "supportedVersionIds" : [ "23" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "23" ]
+  }, {
+    "brand" : "motorola",
+    "codename" : "griffin",
+    "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
+    "id" : "griffin",
+    "manufacturer" : "Motorola",
+    "name" : "Moto Z XT1650",
+    "screenDensity" : 640,
+    "screenX" : 1440,
+    "screenY" : 2560,
+    "supportedAbis" : [ "arm64-v8a", "armeabi-v7a", "armeabi" ],
+    "supportedVersionIds" : [ "24" ]
   }, {
     "brand" : "LG",
     "codename" : "hammerhead",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "hammerhead",
     "manufacturer" : "LG",
     "name" : "Nexus 5",
@@ -403,12 +417,12 @@
     "screenX" : 1080,
     "screenY" : 1920,
     "supportedAbis" : [ "armeabi-v7a", "armeabi" ],
-    "supportedVersionIds" : [ "21", "23" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "21", "23" ]
   }, {
     "brand" : "Motorola",
     "codename" : "harpia",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "harpia",
     "manufacturer" : "Motorola",
     "name" : "Moto G Play (4th Gen) XT1607",
@@ -416,12 +430,12 @@
     "screenX" : 720,
     "screenY" : 1280,
     "supportedAbis" : [ "armeabi-v7a", "armeabi" ],
-    "supportedVersionIds" : [ "23" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "23" ]
   }, {
     "brand" : "Samsung",
     "codename" : "hero2lte",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "hero2lte",
     "manufacturer" : "Samsung",
     "name" : "Galaxy S7 edge",
@@ -429,12 +443,12 @@
     "screenX" : 2560,
     "screenY" : 1440,
     "supportedAbis" : [ "arm64-v8a", "armeabi-v7a", "armeabi" ],
-    "supportedVersionIds" : [ "23" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "23" ]
   }, {
     "brand" : "Samsung",
     "codename" : "herolte",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "herolte",
     "manufacturer" : "Samsung",
     "name" : "Galaxy S7",
@@ -442,12 +456,12 @@
     "screenX" : 2560,
     "screenY" : 1440,
     "supportedAbis" : [ "arm64-v8a", "armeabi-v7a", "armeabi" ],
-    "supportedVersionIds" : [ "23", "24" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "23", "24" ]
   }, {
     "brand" : "Samsung",
     "codename" : "hlte",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "hlte",
     "manufacturer" : "Samsung",
     "name" : "Galaxy Note 3 Duos",
@@ -455,12 +469,12 @@
     "screenX" : 1080,
     "screenY" : 1920,
     "supportedAbis" : [ "armeabi-v7a", "armeabi" ],
-    "supportedVersionIds" : [ "19" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "19" ]
   }, {
     "brand" : "HTC",
     "codename" : "htc_m8",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "htc_m8",
     "manufacturer" : "HTC",
     "name" : "HTC One (M8)",
@@ -468,12 +482,12 @@
     "screenX" : 1080,
     "screenY" : 1920,
     "supportedAbis" : [ "armeabi-v7a", "armeabi" ],
-    "supportedVersionIds" : [ "19" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "19" ]
   }, {
     "brand" : "Huawei",
     "codename" : "hwALE-H",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "hwALE-H",
     "manufacturer" : "Huawei",
     "name" : "Huawei P8 lite",
@@ -481,12 +495,12 @@
     "screenX" : 720,
     "screenY" : 1280,
     "supportedAbis" : [ "arm64-v8a", "armeabi-v7a", "armeabi" ],
-    "supportedVersionIds" : [ "21" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "21" ]
   }, {
     "brand" : "Samsung",
     "codename" : "j1acevelte",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "j1acevelte",
     "manufacturer" : "Samsung",
     "name" : "Galaxy J1 ace SM-J111M",
@@ -494,12 +508,12 @@
     "screenX" : 480,
     "screenY" : 800,
     "supportedAbis" : [ "armeabi-v7a", "armeabi" ],
-    "supportedVersionIds" : [ "22" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "22" ]
   }, {
     "brand" : "Samsung",
     "codename" : "j5lte",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "j5lte",
     "manufacturer" : "Samsung",
     "name" : "Galaxy J5",
@@ -507,12 +521,12 @@
     "screenX" : 720,
     "screenY" : 1280,
     "supportedAbis" : [ "armeabi-v7a", "armeabi" ],
-    "tags" : [ "deprecated" ],
-    "formFactor" : "PHONE"
+    "tags" : [ "deprecated" ]
   }, {
     "brand" : "Samsung",
     "codename" : "j7xelte",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "j7xelte",
     "manufacturer" : "Samsung",
     "name" : "Galaxy J7 (SM-J710MN)",
@@ -520,12 +534,12 @@
     "screenX" : 720,
     "screenY" : 1280,
     "supportedAbis" : [ "armeabi-v7a", "armeabi" ],
-    "supportedVersionIds" : [ "23" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "23" ]
   }, {
     "brand" : "Samsung",
     "codename" : "lt02wifi",
     "form" : "PHYSICAL",
+    "formFactor" : "TABLET",
     "id" : "lt02wifi",
     "manufacturer" : "Samsung",
     "name" : "Galaxy Tab 3",
@@ -533,12 +547,12 @@
     "screenX" : 1024,
     "screenY" : 600,
     "supportedAbis" : [ "armeabi-v7a", "armeabi" ],
-    "supportedVersionIds" : [ "19" ],
-    "formFactor" : "TABLET"
+    "supportedVersionIds" : [ "19" ]
   }, {
     "brand" : "lge",
     "codename" : "lucye",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "lucye",
     "manufacturer" : "LG",
     "name" : "LG G6 LGUS997",
@@ -546,12 +560,12 @@
     "screenX" : 1440,
     "screenY" : 2880,
     "supportedAbis" : [ "arm64-v8a", "armeabi-v7a", "armeabi" ],
-    "supportedVersionIds" : [ "24" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "24" ]
   }, {
     "brand" : "lge",
     "codename" : "lv0",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "lv0",
     "manufacturer" : "LG",
     "name" : "LG K3",
@@ -559,12 +573,12 @@
     "screenX" : 480,
     "screenY" : 854,
     "supportedAbis" : [ "armeabi-v7a", "armeabi" ],
-    "supportedVersionIds" : [ "23" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "23" ]
   }, {
     "brand" : "Samsung",
     "codename" : "m0",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "m0",
     "manufacturer" : "Samsung",
     "name" : "Samsung Galaxy S3",
@@ -572,12 +586,12 @@
     "screenX" : 720,
     "screenY" : 1280,
     "supportedAbis" : [ "armeabi-v7a", "armeabi" ],
-    "supportedVersionIds" : [ "18" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "18" ]
   }, {
     "brand" : "LG",
     "codename" : "mako",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "mako",
     "manufacturer" : "LG",
     "name" : "Nexus 4",
@@ -585,12 +599,12 @@
     "screenX" : 768,
     "screenY" : 1280,
     "supportedAbis" : [ "armeabi-v7a", "armeabi" ],
-    "tags" : [ "deprecated" ],
-    "formFactor" : "PHONE"
+    "tags" : [ "deprecated" ]
   }, {
     "brand" : "essential",
     "codename" : "mata",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "mata",
     "manufacturer" : "Essential Products",
     "name" : "Essential PH-1",
@@ -598,12 +612,12 @@
     "screenX" : 1312,
     "screenY" : 2560,
     "supportedAbis" : [ "arm64-v8a", "armeabi-v7a", "armeabi" ],
-    "supportedVersionIds" : [ "25" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "25" ]
   }, {
     "brand" : "lge",
     "codename" : "mlv1",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "mlv1",
     "manufacturer" : "LG",
     "name" : "LG K4 (LG-X230)",
@@ -611,12 +625,12 @@
     "screenX" : 480,
     "screenY" : 854,
     "supportedAbis" : [ "armeabi-v7a", "armeabi" ],
-    "supportedVersionIds" : [ "23" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "23" ]
   }, {
     "brand" : "Motorola",
     "codename" : "osprey_umts",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "osprey_umts",
     "manufacturer" : "Motorola",
     "name" : "Moto G (3rd Gen)",
@@ -624,12 +638,12 @@
     "screenX" : 720,
     "screenY" : 1280,
     "supportedAbis" : [ "armeabi-v7a", "armeabi" ],
-    "tags" : [ "deprecated" ],
-    "formFactor" : "PHONE"
+    "tags" : [ "deprecated" ]
   }, {
     "brand" : "LG",
     "codename" : "p1",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "p1",
     "manufacturer" : "LG",
     "name" : "LG G4",
@@ -637,12 +651,12 @@
     "screenX" : 2560,
     "screenY" : 1440,
     "supportedAbis" : [ "armeabi-v7a", "armeabi" ],
-    "tags" : [ "deprecated" ],
-    "formFactor" : "PHONE"
+    "tags" : [ "deprecated" ]
   }, {
     "brand" : "motorola",
     "codename" : "potter",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "potter",
     "manufacturer" : "Motorola",
     "name" : "Moto G (5) Plus",
@@ -650,12 +664,12 @@
     "screenX" : 1080,
     "screenY" : 1920,
     "supportedAbis" : [ "armeabi-v7a", "armeabi" ],
-    "supportedVersionIds" : [ "24" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "24" ]
   }, {
     "brand" : "Google",
     "codename" : "sailfish",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "sailfish",
     "manufacturer" : "Google",
     "name" : "Pixel",
@@ -663,12 +677,12 @@
     "screenX" : 1920,
     "screenY" : 1080,
     "supportedAbis" : [ "arm64-v8a", "armeabi-v7a", "armeabi" ],
-    "supportedVersionIds" : [ "25", "26", "27", "28" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "25", "26", "27", "28" ]
   }, {
     "brand" : "Samsung",
     "codename" : "serranolte",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "serranolte",
     "manufacturer" : "Samsung",
     "name" : "Galaxy S4 mini",
@@ -676,12 +690,12 @@
     "screenX" : 540,
     "screenY" : 960,
     "supportedAbis" : [ "armeabi-v7a", "armeabi" ],
-    "tags" : [ "deprecated" ],
-    "formFactor" : "PHONE"
+    "tags" : [ "deprecated" ]
   }, {
     "brand" : "Motorola",
     "codename" : "shamu",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "shamu",
     "manufacturer" : "Motorola",
     "name" : "Nexus 6",
@@ -689,12 +703,12 @@
     "screenX" : 1440,
     "screenY" : 2560,
     "supportedAbis" : [ "armeabi-v7a", "armeabi" ],
-    "supportedVersionIds" : [ "21", "22", "23" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "21", "22", "23" ]
   }, {
     "brand" : "samsung",
     "codename" : "star2qlteue",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "star2qlteue",
     "manufacturer" : "Samsung",
     "name" : "Samsung Galaxy S9+ (US)",
@@ -702,12 +716,12 @@
     "screenX" : 1080,
     "screenY" : 2220,
     "supportedAbis" : [ "arm64-v8a", "armeabi-v7a", "armeabi" ],
-    "supportedVersionIds" : [ "26" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "26" ]
   }, {
     "brand" : "samsung",
     "codename" : "starqlteue",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "starqlteue",
     "manufacturer" : "Samsung",
     "name" : "Samsung Galaxy S9 (US)",
@@ -715,12 +729,12 @@
     "screenX" : 1080,
     "screenY" : 2220,
     "supportedAbis" : [ "arm64-v8a", "armeabi-v7a", "armeabi" ],
-    "supportedVersionIds" : [ "26" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "26" ]
   }, {
     "brand" : "Samsung",
     "codename" : "t03g",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "t03g",
     "manufacturer" : "Samsung",
     "name" : "Galaxy Note 2",
@@ -728,12 +742,12 @@
     "screenX" : 720,
     "screenY" : 1280,
     "supportedAbis" : [ "armeabi-v7a", "armeabi" ],
-    "tags" : [ "deprecated" ],
-    "formFactor" : "PHONE"
+    "tags" : [ "deprecated" ]
   }, {
     "brand" : "Google",
     "codename" : "taimen",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "taimen",
     "manufacturer" : "Google",
     "name" : "Pixel 2 XL",
@@ -741,12 +755,12 @@
     "screenX" : 1440,
     "screenY" : 2880,
     "supportedAbis" : [ "arm64-v8a", "armeabi-v7a", "armeabi" ],
-    "supportedVersionIds" : [ "26", "27" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "26", "27" ]
   }, {
     "brand" : "Motorola",
     "codename" : "titan_umts",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "titan_umts",
     "manufacturer" : "Motorola",
     "name" : "Moto G (2nd Gen)",
@@ -754,12 +768,12 @@
     "screenX" : 720,
     "screenY" : 1280,
     "supportedAbis" : [ "armeabi-v7a", "armeabi" ],
-    "tags" : [ "deprecated" ],
-    "formFactor" : "PHONE"
+    "tags" : [ "deprecated" ]
   }, {
     "brand" : "Samsung",
     "codename" : "trelte",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "trelte",
     "manufacturer" : "Samsung",
     "name" : "Galaxy Note 4",
@@ -767,12 +781,12 @@
     "screenX" : 1080,
     "screenY" : 1920,
     "supportedAbis" : [ "armeabi-v7a", "armeabi" ],
-    "tags" : [ "deprecated" ],
-    "formFactor" : "PHONE"
+    "tags" : [ "deprecated" ]
   }, {
     "brand" : "Motorola",
     "codename" : "victara",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "victara",
     "manufacturer" : "Motorola",
     "name" : "Moto X",
@@ -780,12 +794,12 @@
     "screenX" : 1080,
     "screenY" : 1920,
     "supportedAbis" : [ "armeabi-v7a", "armeabi" ],
-    "supportedVersionIds" : [ "19" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "19" ]
   }, {
     "brand" : "Google",
     "codename" : "walleye",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "walleye",
     "manufacturer" : "Google",
     "name" : "Pixel 2",
@@ -794,12 +808,12 @@
     "screenY" : 1920,
     "supportedAbis" : [ "arm64-v8a", "armeabi-v7a", "armeabi" ],
     "supportedVersionIds" : [ "26", "27", "28" ],
-    "tags" : [ "default" ],
-    "formFactor" : "PHONE"
+    "tags" : [ "default" ]
   }, {
     "brand" : "Samsung",
     "codename" : "zeroflte",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "zeroflte",
     "manufacturer" : "Samsung",
     "name" : "Galaxy S6",
@@ -807,12 +821,12 @@
     "screenX" : 1440,
     "screenY" : 2560,
     "supportedAbis" : [ "arm64-v8a", "armeabi-v7a", "armeabi" ],
-    "supportedVersionIds" : [ "23" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "23" ]
   }, {
     "brand" : "Samsung",
     "codename" : "zerolte",
     "form" : "PHYSICAL",
+    "formFactor" : "PHONE",
     "id" : "zerolte",
     "manufacturer" : "Samsung",
     "name" : "Galaxy S6 Edge",
@@ -820,8 +834,7 @@
     "screenX" : 1440,
     "screenY" : 2560,
     "supportedAbis" : [ "arm64-v8a", "armeabi-v7a", "armeabi" ],
-    "tags" : [ "deprecated" ],
-    "formFactor" : "PHONE"
+    "tags" : [ "deprecated" ]
   } ],
   "runtimeConfiguration" : {
     "locales" : [ {

--- a/test_runner/src/test/kotlin/ftl/fixtures/ios_catalog.json
+++ b/test_runner/src/test/kotlin/ftl/fixtures/ios_catalog.json
@@ -1,71 +1,77 @@
 {
   "models" : [ {
+    "deviceCapabilities" : [ "accelerometer", "armv6", "armv7", "arm64", "auto-focus-camera", "bluetooth-le", "front-facing-camera", "gamekit", "gyroscope", "location-services", "magnetometer", "metal", "microphone", "opengles-1", "opengles-2", "opengles-3", "peer-peer", "still-camera", "video-camera", "wifi", "arkit" ],
+    "formFactor" : "TABLET",
     "id" : "ipad5",
     "name" : "iPad (5th generation)",
-    "supportedVersionIds" : [ "11.2" ],
-    "deviceCapabilities" : [ "accelerometer", "armv6", "armv7", "arm64", "auto-focus-camera", "bluetooth-le", "front-facing-camera", "gamekit", "gyroscope", "location-services", "magnetometer", "metal", "microphone", "opengles-1", "opengles-2", "opengles-3", "peer-peer", "still-camera", "video-camera", "wifi", "arkit" ],
-    "formFactor" : "TABLET"
+    "supportedVersionIds" : [ "11.2", "12.0" ]
   }, {
+    "deviceCapabilities" : [ "accelerometer", "armv6", "armv7", "arm64", "auto-focus-camera", "bluetooth-le", "front-facing-camera", "gamekit", "gyroscope", "location-services", "magnetometer", "metal", "microphone", "opengles-1", "opengles-2", "opengles-3", "peer-peer", "still-camera", "video-camera", "wifi" ],
+    "formFactor" : "TABLET",
     "id" : "ipadmini4",
     "name" : "iPad mini 4",
-    "supportedVersionIds" : [ "11.2" ],
-    "deviceCapabilities" : [ "accelerometer", "armv6", "armv7", "arm64", "auto-focus-camera", "bluetooth-le", "front-facing-camera", "gamekit", "gyroscope", "location-services", "magnetometer", "metal", "microphone", "opengles-1", "opengles-2", "opengles-3", "peer-peer", "still-camera", "video-camera", "wifi" ],
-    "formFactor" : "TABLET"
+    "supportedVersionIds" : [ "11.2", "12.0" ]
   }, {
+    "deviceCapabilities" : [ "accelerometer", "armv6", "armv7", "arm64", "auto-focus-camera", "bluetooth-le", "front-facing-camera", "gamekit", "gyroscope", "location-services", "magnetometer", "metal", "microphone", "opengles-1", "opengles-2", "opengles-3", "peer-peer", "still-camera", "video-camera", "wifi", "arkit", "camera-flash" ],
+    "formFactor" : "TABLET",
     "id" : "ipadpro_105",
     "name" : "iPad Pro (10.5-inch)",
-    "supportedVersionIds" : [ "11.2" ],
-    "deviceCapabilities" : [ "accelerometer", "armv6", "armv7", "arm64", "auto-focus-camera", "bluetooth-le", "front-facing-camera", "gamekit", "gyroscope", "location-services", "magnetometer", "metal", "microphone", "opengles-1", "opengles-2", "opengles-3", "peer-peer", "still-camera", "video-camera", "wifi", "arkit", "camera-flash" ],
-    "formFactor" : "TABLET"
+    "supportedVersionIds" : [ "11.2" ]
   }, {
+    "deviceCapabilities" : [ "accelerometer", "armv6", "armv7", "arm64", "auto-focus-camera", "bluetooth-le", "front-facing-camera", "gamekit", "gyroscope", "location-services", "magnetometer", "metal", "microphone", "opengles-1", "opengles-2", "opengles-3", "peer-peer", "still-camera", "video-camera", "wifi", "camera-flash", "gps", "healthkit", "sms", "telephony" ],
+    "formFactor" : "PHONE",
+    "id" : "iphone6",
+    "name" : "iPhone 6",
+    "supportedVersionIds" : [ "11.4" ]
+  }, {
+    "deviceCapabilities" : [ "accelerometer", "armv6", "armv7", "arm64", "auto-focus-camera", "bluetooth-le", "front-facing-camera", "gamekit", "gyroscope", "location-services", "magnetometer", "metal", "microphone", "opengles-1", "opengles-2", "opengles-3", "peer-peer", "still-camera", "video-camera", "wifi", "arkit", "camera-flash", "gps", "healthkit", "sms", "telephony" ],
+    "formFactor" : "PHONE",
     "id" : "iphone6s",
     "name" : "iPhone 6s",
-    "supportedVersionIds" : [ "10.3", "11.2" ],
-    "deviceCapabilities" : [ "accelerometer", "armv6", "armv7", "arm64", "auto-focus-camera", "bluetooth-le", "front-facing-camera", "gamekit", "gyroscope", "location-services", "magnetometer", "metal", "microphone", "opengles-1", "opengles-2", "opengles-3", "peer-peer", "still-camera", "video-camera", "wifi", "arkit", "camera-flash", "gps", "healthkit", "sms", "telephony" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "10.3", "11.2", "11.4", "12.0" ]
   }, {
+    "deviceCapabilities" : [ "accelerometer", "armv6", "armv7", "arm64", "auto-focus-camera", "bluetooth-le", "front-facing-camera", "gamekit", "gyroscope", "location-services", "magnetometer", "metal", "microphone", "opengles-1", "opengles-2", "opengles-3", "peer-peer", "still-camera", "video-camera", "wifi", "arkit", "camera-flash", "gps", "healthkit", "sms", "telephony" ],
+    "formFactor" : "PHONE",
     "id" : "iphone6splus",
     "name" : "iPhone 6s Plus",
-    "supportedVersionIds" : [ "9.0", "9.1" ],
-    "deviceCapabilities" : [ "accelerometer", "armv6", "armv7", "arm64", "auto-focus-camera", "bluetooth-le", "front-facing-camera", "gamekit", "gyroscope", "location-services", "magnetometer", "metal", "microphone", "opengles-1", "opengles-2", "opengles-3", "peer-peer", "still-camera", "video-camera", "wifi", "arkit", "camera-flash", "gps", "healthkit", "sms", "telephony" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "9.0", "9.1" ]
   }, {
+    "deviceCapabilities" : [ "accelerometer", "armv6", "armv7", "arm64", "auto-focus-camera", "bluetooth-le", "front-facing-camera", "gamekit", "gyroscope", "location-services", "magnetometer", "metal", "microphone", "opengles-1", "opengles-2", "opengles-3", "peer-peer", "still-camera", "video-camera", "wifi", "arkit", "camera-flash", "gps", "healthkit", "nfc", "sms", "telephony" ],
+    "formFactor" : "PHONE",
     "id" : "iphone7",
     "name" : "iPhone 7",
-    "supportedVersionIds" : [ "11.2" ],
-    "deviceCapabilities" : [ "accelerometer", "armv6", "armv7", "arm64", "auto-focus-camera", "bluetooth-le", "front-facing-camera", "gamekit", "gyroscope", "location-services", "magnetometer", "metal", "microphone", "opengles-1", "opengles-2", "opengles-3", "peer-peer", "still-camera", "video-camera", "wifi", "arkit", "camera-flash", "gps", "healthkit", "nfc", "sms", "telephony" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "11.2", "11.4", "12.0" ]
   }, {
+    "deviceCapabilities" : [ "accelerometer", "armv6", "armv7", "arm64", "auto-focus-camera", "bluetooth-le", "front-facing-camera", "gamekit", "gyroscope", "location-services", "magnetometer", "metal", "microphone", "opengles-1", "opengles-2", "opengles-3", "peer-peer", "still-camera", "video-camera", "wifi", "arkit", "camera-flash", "gps", "healthkit", "nfc", "sms", "telephony" ],
+    "formFactor" : "PHONE",
     "id" : "iphone7plus",
     "name" : "iPhone 7 Plus",
-    "supportedVersionIds" : [ "11.2" ],
-    "deviceCapabilities" : [ "accelerometer", "armv6", "armv7", "arm64", "auto-focus-camera", "bluetooth-le", "front-facing-camera", "gamekit", "gyroscope", "location-services", "magnetometer", "metal", "microphone", "opengles-1", "opengles-2", "opengles-3", "peer-peer", "still-camera", "video-camera", "wifi", "arkit", "camera-flash", "gps", "healthkit", "nfc", "sms", "telephony" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "11.2", "11.4", "12.0" ]
   }, {
+    "deviceCapabilities" : [ "accelerometer", "armv6", "armv7", "arm64", "auto-focus-camera", "bluetooth-le", "front-facing-camera", "gamekit", "gyroscope", "location-services", "magnetometer", "metal", "microphone", "opengles-1", "opengles-2", "opengles-3", "peer-peer", "still-camera", "video-camera", "wifi", "arkit", "camera-flash", "gps", "healthkit", "nfc", "sms", "telephony" ],
+    "formFactor" : "PHONE",
     "id" : "iphone8",
     "name" : "iPhone 8",
-    "supportedVersionIds" : [ "11.2" ],
-    "tags" : [ "default" ],
-    "deviceCapabilities" : [ "accelerometer", "armv6", "armv7", "arm64", "auto-focus-camera", "bluetooth-le", "front-facing-camera", "gamekit", "gyroscope", "location-services", "magnetometer", "metal", "microphone", "opengles-1", "opengles-2", "opengles-3", "peer-peer", "still-camera", "video-camera", "wifi", "arkit", "camera-flash", "gps", "healthkit", "nfc", "sms", "telephony" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "11.2", "11.4", "12.0" ],
+    "tags" : [ "default" ]
   }, {
+    "deviceCapabilities" : [ "accelerometer", "armv6", "armv7", "arm64", "auto-focus-camera", "bluetooth-le", "front-facing-camera", "gamekit", "gyroscope", "location-services", "magnetometer", "metal", "microphone", "opengles-1", "opengles-2", "opengles-3", "peer-peer", "still-camera", "video-camera", "wifi", "arkit", "camera-flash", "gps", "healthkit", "nfc", "sms", "telephony" ],
+    "formFactor" : "PHONE",
     "id" : "iphone8plus",
     "name" : "iPhone 8 Plus",
-    "supportedVersionIds" : [ "11.2" ],
-    "deviceCapabilities" : [ "accelerometer", "armv6", "armv7", "arm64", "auto-focus-camera", "bluetooth-le", "front-facing-camera", "gamekit", "gyroscope", "location-services", "magnetometer", "metal", "microphone", "opengles-1", "opengles-2", "opengles-3", "peer-peer", "still-camera", "video-camera", "wifi", "arkit", "camera-flash", "gps", "healthkit", "nfc", "sms", "telephony" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "11.2", "11.4", "12.0" ]
   }, {
+    "deviceCapabilities" : [ "accelerometer", "armv6", "armv7", "arm64", "auto-focus-camera", "bluetooth-le", "front-facing-camera", "gamekit", "gyroscope", "location-services", "magnetometer", "metal", "microphone", "opengles-1", "opengles-2", "opengles-3", "peer-peer", "still-camera", "video-camera", "wifi", "arkit", "camera-flash", "gps", "healthkit", "sms", "telephony" ],
+    "formFactor" : "PHONE",
     "id" : "iphonese",
     "name" : "iPhone SE",
-    "supportedVersionIds" : [ "11.2" ],
-    "deviceCapabilities" : [ "accelerometer", "armv6", "armv7", "arm64", "auto-focus-camera", "bluetooth-le", "front-facing-camera", "gamekit", "gyroscope", "location-services", "magnetometer", "metal", "microphone", "opengles-1", "opengles-2", "opengles-3", "peer-peer", "still-camera", "video-camera", "wifi", "arkit", "camera-flash", "gps", "healthkit", "sms", "telephony" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "11.2", "11.4", "12.0" ]
   }, {
+    "deviceCapabilities" : [ "accelerometer", "armv6", "armv7", "arm64", "auto-focus-camera", "bluetooth-le", "front-facing-camera", "gamekit", "gyroscope", "location-services", "magnetometer", "metal", "microphone", "opengles-1", "opengles-2", "opengles-3", "peer-peer", "still-camera", "video-camera", "wifi", "arkit", "camera-flash", "gps", "healthkit", "nfc", "sms", "telephony" ],
+    "formFactor" : "PHONE",
     "id" : "iphonex",
     "name" : "iPhone X",
-    "supportedVersionIds" : [ "11.2" ],
-    "deviceCapabilities" : [ "accelerometer", "armv6", "armv7", "arm64", "auto-focus-camera", "bluetooth-le", "front-facing-camera", "gamekit", "gyroscope", "location-services", "magnetometer", "metal", "microphone", "opengles-1", "opengles-2", "opengles-3", "peer-peer", "still-camera", "video-camera", "wifi", "arkit", "camera-flash", "gps", "healthkit", "nfc", "sms", "telephony" ],
-    "formFactor" : "PHONE"
+    "supportedVersionIds" : [ "11.2", "11.4", "12.0" ]
   } ],
   "runtimeConfiguration" : {
     "locales" : [ {
@@ -2345,26 +2351,41 @@
   "versions" : [ {
     "id" : "9.0",
     "majorVersion" : 9,
-    "supportedXcodeVersionIds" : [ "9.2" ]
+    "supportedXcodeVersionIds" : [ "9.2", "9.4.1", "10.0", "10.1" ]
   }, {
     "id" : "9.1",
     "majorVersion" : 9,
     "minorVersion" : 1,
-    "supportedXcodeVersionIds" : [ "9.2" ]
+    "supportedXcodeVersionIds" : [ "9.2", "9.4.1", "10.0", "10.1" ]
   }, {
     "id" : "10.3",
     "majorVersion" : 10,
     "minorVersion" : 3,
-    "supportedXcodeVersionIds" : [ "9.2" ]
+    "supportedXcodeVersionIds" : [ "9.2", "9.4.1", "10.0", "10.1" ]
   }, {
     "id" : "11.2",
     "majorVersion" : 11,
     "minorVersion" : 2,
-    "tags" : [ "default" ],
-    "supportedXcodeVersionIds" : [ "9.2" ]
+    "supportedXcodeVersionIds" : [ "9.2", "9.4.1", "10.0", "10.1" ],
+    "tags" : [ "default" ]
+  }, {
+    "id" : "11.4",
+    "majorVersion" : 11,
+    "minorVersion" : 4,
+    "supportedXcodeVersionIds" : [ "9.4.1", "10.0", "10.1" ]
+  }, {
+    "id" : "12.0",
+    "majorVersion" : 12,
+    "supportedXcodeVersionIds" : [ "10.0", "10.1" ]
   } ],
   "xcodeVersions" : [ {
-    "version" : "9.2",
-    "tags" : [ "default" ]
+    "version" : "9.2"
+  }, {
+    "version" : "9.4.1"
+  }, {
+    "version" : "10.0"
+  }, {
+    "tags" : [ "default" ],
+    "version" : "10.1"
   } ]
 }

--- a/test_runner/src/test/kotlin/ftl/reports/utils/ReportManagerTest.kt
+++ b/test_runner/src/test/kotlin/ftl/reports/utils/ReportManagerTest.kt
@@ -27,7 +27,7 @@ class ReportManagerTest {
     fun generate_fromErrorResult() {
         val matrix = TestRunner.matrixPathToObj("./src/test/kotlin/ftl/fixtures/error_result")
         val mockArgs = mock(AndroidArgs::class.java)
-        `when`(mockArgs.junitGcsPath).thenReturn("")
+        `when`(mockArgs.smartFlankGcsPath).thenReturn("")
         ReportManager.generate(matrix, mockArgs)
     }
 
@@ -35,7 +35,7 @@ class ReportManagerTest {
     fun generate_fromSuccessResult() {
         val matrix = TestRunner.matrixPathToObj("./src/test/kotlin/ftl/fixtures/success_result")
         val mockArgs = mock(AndroidArgs::class.java)
-        `when`(mockArgs.junitGcsPath).thenReturn("")
+        `when`(mockArgs.smartFlankGcsPath).thenReturn("")
         ReportManager.generate(matrix, mockArgs)
     }
 }

--- a/test_runner/src/test/kotlin/ftl/reports/utils/ReportManagerTest.kt
+++ b/test_runner/src/test/kotlin/ftl/reports/utils/ReportManagerTest.kt
@@ -9,6 +9,7 @@ import org.junit.Test
 import org.junit.contrib.java.lang.system.SystemErrRule
 import org.junit.contrib.java.lang.system.SystemOutRule
 import org.junit.runner.RunWith
+import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 
 @RunWith(FlankTestRunner::class)
@@ -25,12 +26,16 @@ class ReportManagerTest {
     @Test
     fun generate_fromErrorResult() {
         val matrix = TestRunner.matrixPathToObj("./src/test/kotlin/ftl/fixtures/error_result")
-        ReportManager.generate(matrix, mock(AndroidArgs::class.java))
+        val mockArgs = mock(AndroidArgs::class.java)
+        `when`(mockArgs.junitGcsPath).thenReturn("")
+        ReportManager.generate(matrix, mockArgs)
     }
 
     @Test
     fun generate_fromSuccessResult() {
         val matrix = TestRunner.matrixPathToObj("./src/test/kotlin/ftl/fixtures/success_result")
-        ReportManager.generate(matrix, mock(AndroidArgs::class.java))
+        val mockArgs = mock(AndroidArgs::class.java)
+        `when`(mockArgs.junitGcsPath).thenReturn("")
+        ReportManager.generate(matrix, mockArgs)
     }
 }

--- a/test_runner/src/test/kotlin/ftl/run/GenericTestRunnerTest.kt
+++ b/test_runner/src/test/kotlin/ftl/run/GenericTestRunnerTest.kt
@@ -23,7 +23,7 @@ class GenericTestRunnerTest {
     @Test
     fun testBeforeRunMessage1() {
         val result = beforeRunMessage(createMock(1, listOf(listOf(""))))
-        assert(result, "  1 test / 1 shard = 1 test per shard\n")
+        assert(result, "  1 test / 1 shard\n")
     }
 
     @Test
@@ -31,7 +31,7 @@ class GenericTestRunnerTest {
         val result = beforeRunMessage(createMock(2, listOf(listOf(""))))
         assert(
             result, """
-  1 test / 1 shard = 1 test per shard
+  1 test / 1 shard
   Running 2x
     2 total shards
     2 total tests
@@ -49,7 +49,7 @@ class GenericTestRunnerTest {
         )
         assert(
             result, """
-  6 tests / 6 shards = 1 test per shard
+  6 tests / 6 shards
   Running 2x
     12 total shards
     12 total tests
@@ -62,7 +62,7 @@ class GenericTestRunnerTest {
         val result = beforeRunMessage(createMock(100, listOf(listOf("", "", "", "", ""), listOf("", "", "", "", ""))))
         assert(
             result, """
-  10 tests / 2 shards = 5 tests per shard
+  10 tests / 2 shards
   Running 100x
     200 total shards
     1000 total tests

--- a/test_runner/src/test/kotlin/ftl/shard/ShardTest.kt
+++ b/test_runner/src/test/kotlin/ftl/shard/ShardTest.kt
@@ -2,6 +2,7 @@ package ftl.shard
 
 import com.google.common.truth.Truth.assertThat
 import ftl.args.IArgs
+import ftl.args.IosArgs
 import ftl.reports.xml.model.JUnitTestCase
 import ftl.reports.xml.model.JUnitTestResult
 import ftl.reports.xml.model.JUnitTestSuite
@@ -33,7 +34,7 @@ class ShardTest {
     }
 
     private fun mockArgs(testShards: Int): IArgs {
-        val mockArgs = mock(IArgs::class.java)
+        val mockArgs = mock(IosArgs::class.java)
         `when`(mockArgs.testShards).thenReturn(testShards)
         return mockArgs
     }
@@ -53,7 +54,7 @@ class ShardTest {
 
     @Test
     fun sampleTest() {
-        val reRunTestsToRun = listOf("a#a", "b#b", "c#c", "d#d", "e#e", "f#f", "g#g")
+        val reRunTestsToRun = listOf("a/a", "b/b", "c/c", "d/d", "e/e", "f/f", "g/g")
         val suite = sample()
         val result = Shard.calculateShardsByTime(reRunTestsToRun, suite, mockArgs(3))
 
@@ -65,14 +66,14 @@ class ShardTest {
         assertThat(result.sumByDouble { it.time }).isEqualTo(16.5)
 
         val testNames = mutableListOf<String>()
-        result.forEach {
-            it.testMethods.forEach {
+        result.forEach { shard ->
+            shard.testMethods.forEach {
                 testNames.add(it.name)
             }
         }
 
         testNames.sort()
-        assertThat(testNames).isEqualTo(listOf("a#a", "b#b", "c#c", "d#d", "e#e", "f#f", "g#g"))
+        assertThat(testNames).isEqualTo(listOf("a/a", "b/b", "c/c", "d/d", "e/e", "f/f", "g/g"))
     }
 
     @Test
@@ -90,7 +91,7 @@ class ShardTest {
 
     @Test
     fun mixedNewAndOld() {
-        val testsToRun = listOf("a#a", "b#b", "c#c", "w", "y", "z")
+        val testsToRun = listOf("a/a", "b/b", "c/c", "w", "y", "z")
         val result = Shard.calculateShardsByTime(testsToRun, sample(), mockArgs(4))
         assertThat(result.size).isEqualTo(4)
         assertThat(result.sumByDouble { it.time }).isEqualTo(37.0)

--- a/test_runner/src/test/kotlin/ftl/shard/ShardTest.kt
+++ b/test_runner/src/test/kotlin/ftl/shard/ShardTest.kt
@@ -1,12 +1,15 @@
 package ftl.shard
 
 import com.google.common.truth.Truth.assertThat
+import ftl.args.IArgs
 import ftl.reports.xml.model.JUnitTestCase
 import ftl.reports.xml.model.JUnitTestResult
 import ftl.reports.xml.model.JUnitTestSuite
 import ftl.test.util.FlankTestRunner
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
 
 @RunWith(FlankTestRunner::class)
 class ShardTest {
@@ -29,11 +32,18 @@ class ShardTest {
         return JUnitTestResult(mutableListOf(suite1, suite2))
     }
 
+    private fun mockArgs(testShards: Int): IArgs {
+        val mockArgs = mock(IArgs::class.java)
+        `when`(mockArgs.testShards).thenReturn(testShards)
+        return mockArgs
+    }
+
     @Test
     fun oneTestPerShard() {
         val reRunTestsToRun = listOf("a", "b", "c", "d", "e", "f", "g")
         val suite = sample()
-        val result = Shard.calculateShardsByTime(reRunTestsToRun, suite, 100)
+
+        val result = Shard.calculateShardsByTime(reRunTestsToRun, suite, mockArgs(100))
 
         assertThat(result.size).isEqualTo(7)
         result.forEach {
@@ -45,7 +55,7 @@ class ShardTest {
     fun sampleTest() {
         val reRunTestsToRun = listOf("a#a", "b#b", "c#c", "d#d", "e#e", "f#f", "g#g")
         val suite = sample()
-        val result = Shard.calculateShardsByTime(reRunTestsToRun, suite, 3)
+        val result = Shard.calculateShardsByTime(reRunTestsToRun, suite, mockArgs(3))
 
         assertThat(result.size).isEqualTo(3)
         result.forEach {
@@ -68,7 +78,7 @@ class ShardTest {
     @Test
     fun firstRun() {
         val testsToRun = listOf("a", "b", "c")
-        val result = Shard.calculateShardsByTime(testsToRun, JUnitTestResult(null), 2)
+        val result = Shard.calculateShardsByTime(testsToRun, JUnitTestResult(null), mockArgs(2))
 
         assertThat(result.size).isEqualTo(2)
         assertThat(result.sumByDouble { it.time }).isEqualTo(30.0)
@@ -81,7 +91,7 @@ class ShardTest {
     @Test
     fun mixedNewAndOld() {
         val testsToRun = listOf("a#a", "b#b", "c#c", "w", "y", "z")
-        val result = Shard.calculateShardsByTime(testsToRun, sample(), 4)
+        val result = Shard.calculateShardsByTime(testsToRun, sample(), mockArgs(4))
         assertThat(result.size).isEqualTo(4)
         assertThat(result.sumByDouble { it.time }).isEqualTo(37.0)
 

--- a/test_runner/src/test/kotlin/ftl/shard/ShardTest.kt
+++ b/test_runner/src/test/kotlin/ftl/shard/ShardTest.kt
@@ -1,0 +1,50 @@
+package ftl.shard
+
+import com.google.common.truth.Truth.assertThat
+import ftl.test.util.FlankTestRunner
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(FlankTestRunner::class)
+class ShardTest {
+
+    private val a1 = TestMethod("a", 1.0)
+    private val b2 = TestMethod("b", 2.0)
+    private val c3 = TestMethod("c", 3.0)
+    private val d4 = TestMethod("d", 4.0)
+    private val e999 = TestMethod("d", 999.0)
+    private val rawData = mutableListOf(a1, b2, c3, d4)
+
+    @Test
+    fun fillShard_1234() {
+        val testMethods = mutableListOf<TestMethod>().apply { addAll(rawData) }
+        val startSize = testMethods.size
+        var index = 1
+
+        while (testMethods.iterator().hasNext()) {
+            val testMethod = testMethods.iterator().next()
+
+            assertThat(Shard.build(testMethods, testMethod.time).testMethods).isEqualTo(listOf(testMethod))
+            assertThat(testMethods.size).isEqualTo(startSize - index)
+
+            index += 1
+        }
+
+        assertThat(testMethods).isEmpty()
+    }
+
+    @Test
+    fun fillShard_10() {
+        val testMethods = mutableListOf<TestMethod>().apply { addAll(rawData) }
+
+        val totalTime = testMethods.sumByDouble { it.time }
+        val actual = Shard.build(testMethods, totalTime).testMethods
+        assertThat(actual).isEqualTo(listOf(a1, b2, c3, d4))
+    }
+
+    @Test
+    fun fillShard_999() {
+        val actual = Shard.build(mutableListOf(e999), 0.0).testMethods
+        assertThat(actual).isEqualTo(listOf(e999))
+    }
+}

--- a/test_runner/src/test/kotlin/ftl/shard/ShardTest.kt
+++ b/test_runner/src/test/kotlin/ftl/shard/ShardTest.kt
@@ -108,10 +108,10 @@ class ShardTest {
     @Test
     fun performance_calculateShardsByTime() {
         val testsToRun = mutableListOf<String>()
-        repeat(1_000_000) { index -> testsToRun.add("$index/$index")}
+        repeat(1_000_000) { index -> testsToRun.add("$index/$index") }
 
         val nano = measureNanoTime {
-           Shard.calculateShardsByTime(testsToRun, JUnitTestResult(null), mockArgs(4))
+            Shard.calculateShardsByTime(testsToRun, JUnitTestResult(null), mockArgs(4))
         }
 
         val ms = TimeUnit.NANOSECONDS.toMillis(nano)

--- a/test_runner/src/test/kotlin/ftl/shard/ShardTest.kt
+++ b/test_runner/src/test/kotlin/ftl/shard/ShardTest.kt
@@ -11,6 +11,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
+import java.util.concurrent.TimeUnit
+import kotlin.system.measureNanoTime
 
 @RunWith(FlankTestRunner::class)
 class ShardTest {
@@ -101,5 +103,19 @@ class ShardTest {
         assertThat(ordered[1].testMethods.size).isEqualTo(1)
         assertThat(ordered[2].testMethods.size).isEqualTo(1)
         assertThat(ordered[3].testMethods.size).isEqualTo(3)
+    }
+
+    @Test
+    fun performance_calculateShardsByTime() {
+        val testsToRun = mutableListOf<String>()
+        repeat(1_000_000) { index -> testsToRun.add("$index/$index")}
+
+        val nano = measureNanoTime {
+           Shard.calculateShardsByTime(testsToRun, JUnitTestResult(null), mockArgs(4))
+        }
+
+        val ms = TimeUnit.NANOSECONDS.toMillis(nano)
+        println("Shards calculated in $ms ms")
+        assertThat(ms).isLessThan(5000)
     }
 }


### PR DESCRIPTION
After each test run, the JUnit XML file is uploaded to Google storage

## To Do

- [x] Download JUnit XML
- [x] Merge JUnit XML (retain only passing tests with timing info)
- [x] Upload JUnit XML
- [x] Shard tests based on JUnit XML timing (see https://github.com/TestArmada/flank/pull/239)
- [x] Restore test methods always run
- [x] Verify Android shards correctly
- [x] Add iOS support

## Example

<img width="737" alt="smart_flank_0" src="https://user-images.githubusercontent.com/1173057/48653968-05d6be00-e9d7-11e8-8b0a-100a639e36af.png">
<img width="684" alt="smart_flank_1" src="https://user-images.githubusercontent.com/1173057/48653969-05d6be00-e9d7-11e8-9606-89c7ff1a60ad.png">
<img width="789" alt="smart_flank_2" src="https://user-images.githubusercontent.com/1173057/48653966-05d6be00-e9d7-11e8-8105-03817cc6a492.png">
<img width="683" alt="smart_flank_3" src="https://user-images.githubusercontent.com/1173057/48653965-05d6be00-e9d7-11e8-9acb-a3eb4844d21a.png">