### PR TITLE
Download PNGs after test run

### DIFF
--- a/test_runner/src/main/kotlin/ftl/run/TestRunner.kt
+++ b/test_runner/src/main/kotlin/ftl/run/TestRunner.kt
@@ -209,7 +209,8 @@ object TestRunner {
 
                     result.iterateAll().forEach { blob ->
                         val blobPath = blob.blobId.name
-                        if (blobPath.matches(ArtifactRegex.testResultRgx)) {
+                        if (blobPath.matches(ArtifactRegex.testResultRgx) ||
+                            blobPath.matches(ArtifactRegex.screenshotRgx)) {
                             val downloadFile = Paths.get(FtlConstants.localResultsDir, blobPath)
                             print(".")
                             if (!downloadFile.toFile().exists()) {


### PR DESCRIPTION
According to the KDoc of `TestRunner#fetchArtifacts` besides the test results also the PNGs should be downloaded