### PR TITLE
Add --test-runner-class

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,10 @@ gcloud:
   ## Monitor and record performance metrics: CPU, memory, network usage, and FPS (game-loop only).
   ## Enabled by default, use --no-performance-metrics to disable.
   # performance-metrics: true
+  
+  ## The fully-qualified Java class name of the instrumentation test runner 
+  ## (default: the last name extracted from the APK manifest).
+  # test-runner-class: com.foo.TestRunner
 
   ## A list of one or more test target filters to apply (default: run all test targets).
   ## Each target filter must be fully qualified with the package name, class name, or test annotation desired.

--- a/test_runner/flank.yml
+++ b/test_runner/flank.yml
@@ -68,6 +68,10 @@ gcloud:
   ## Enabled by default, use --no-performance-metrics to disable.
   # performance-metrics: true
 
+  ## The fully-qualified Java class name of the instrumentation test runner
+  ## (default: the last name extracted from the APK manifest).
+  # test-runner-class: com.foo.TestRunner
+
   ## A list of one or more test target filters to apply (default: run all test targets).
   ## Each target filter must be fully qualified with the package name, class name, or test annotation desired.
   ## Supported test filters by am instrument -e … include:

--- a/test_runner/src/main/kotlin/ftl/args/AndroidArgs.kt
+++ b/test_runner/src/main/kotlin/ftl/args/AndroidArgs.kt
@@ -56,6 +56,7 @@ class AndroidArgs(
     val environmentVariables = cli?.environmentVariables ?: androidGcloud.environmentVariables
     val directoriesToPull = cli?.directoriesToPull ?: androidGcloud.directoriesToPull
     val performanceMetrics = cli?.performanceMetrics ?: cli?.noPerformanceMetrics?.not() ?: androidGcloud.performanceMetrics
+    val testRunnerClass = cli?.testRunnerClass ?: androidGcloud.testRunnerClass
     val testTargets = cli?.testTargets ?: androidGcloud.testTargets.filterNotNull()
     val devices = cli?.device ?: androidGcloud.device
 
@@ -126,6 +127,7 @@ ${mapToString(environmentVariables)}
       directories-to-pull:
 ${listToString(directoriesToPull)}
       performance-metrics: $performanceMetrics
+      test-runner-class: $testRunnerClass
       test-targets:
 ${listToString(testTargets)}
       device:

--- a/test_runner/src/main/kotlin/ftl/args/yml/AndroidGcloudYml.kt
+++ b/test_runner/src/main/kotlin/ftl/args/yml/AndroidGcloudYml.kt
@@ -32,6 +32,9 @@ class AndroidGcloudYmlParams(
     @field:JsonProperty("performance-metrics")
     val performanceMetrics: Boolean = true,
 
+    @field:JsonProperty("test-runner-class")
+    val testRunnerClass: String? = null,
+
     @field:JsonProperty("test-targets")
     val testTargets: List<String?> = emptyList(),
 
@@ -40,7 +43,7 @@ class AndroidGcloudYmlParams(
     companion object : IYmlKeys {
         override val keys = listOf(
             "app", "test", "auto-google-login", "use-orchestrator", "environment-variables",
-            "directories-to-pull", "performance-metrics", "test-targets", "device"
+            "directories-to-pull", "performance-metrics", "test-runner-class", "test-targets", "device"
         )
     }
 

--- a/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidRunCommand.kt
+++ b/test_runner/src/main/kotlin/ftl/cli/firebase/test/android/AndroidRunCommand.kt
@@ -133,6 +133,13 @@ class AndroidRunCommand : Runnable {
     var noPerformanceMetrics: Boolean? = null
 
     @Option(
+        names = ["--test-runner-class"],
+        description = ["The fully-qualified Java class name of the instrumentation test runner (default: the last name extracted " +
+                "from the APK manifest)."]
+    )
+    var testRunnerClass: String? = null
+
+    @Option(
         names = ["--test-targets"],
         split = ",",
         description = ["A list of one or more test target filters to apply " +

--- a/test_runner/src/main/kotlin/ftl/gc/GcAndroidTestMatrix.kt
+++ b/test_runner/src/main/kotlin/ftl/gc/GcAndroidTestMatrix.kt
@@ -48,6 +48,10 @@ object GcAndroidTestMatrix {
             .setAppApk(FileReference().setGcsPath(appApkGcsPath))
             .setTestApk(FileReference().setGcsPath(testApkGcsPath))
 
+        if (args.testRunnerClass != null) {
+            androidInstrumentation.testRunnerClass = args.testRunnerClass
+        }
+
         if (args.useOrchestrator) {
             androidInstrumentation.orchestratorOption = "USE_ORCHESTRATOR"
         }

--- a/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
+++ b/test_runner/src/test/kotlin/ftl/args/AndroidArgsTest.kt
@@ -45,6 +45,7 @@ class AndroidArgsTest {
           - /sdcard/screenshots
           - /sdcard/screenshots2
           performance-metrics: false
+          test-runner-class: com.foo.TestRunner
           test-targets:
           - class com.example.app.ExampleUiTest#testPasses
           - class com.example.app.ExampleUiTest#testFails
@@ -163,6 +164,7 @@ class AndroidArgsTest {
             assert(environmentVariables, linkedMapOf("clearPackageData" to "true", "randomEnvVar" to "false"))
             assert(directoriesToPull, listOf("/sdcard/screenshots", "/sdcard/screenshots2"))
             assert(performanceMetrics, false)
+            assert(testRunnerClass, "com.foo.TestRunner")
             assert(
                 testTargets,
                 listOf(
@@ -218,6 +220,7 @@ AndroidArgs
         - /sdcard/screenshots
         - /sdcard/screenshots2
       performance-metrics: false
+      test-runner-class: com.foo.TestRunner
       test-targets:
         - class com.example.app.ExampleUiTest#testPasses
         - class com.example.app.ExampleUiTest#testFails
@@ -281,6 +284,7 @@ AndroidArgs
             assert(environmentVariables, emptyMap<String, String>())
             assert(directoriesToPull, empty)
             assert(performanceMetrics, true)
+            assert(testRunnerClass, null)
             assert(testTargets, empty)
             assert(devices, listOf(Device("NexusLowRes", "28")))
             assert(flakyTestAttempts, 0)
@@ -512,6 +516,22 @@ AndroidArgs
 
         val androidArgs = AndroidArgs.load(yaml, cli)
         assertThat(androidArgs.performanceMetrics).isFalse()
+    }
+
+    @Test
+    fun cli_testRunnerClass() {
+        val cli = AndroidRunCommand()
+        CommandLine(cli).parse("--test-runner-class=com.foo.bar.TestRunner")
+
+        val yaml = """
+        gcloud:
+          app: $appApk
+          test: $testApk
+      """
+        assertThat(AndroidArgs.load(yaml).testRunnerClass).isNull()
+
+        val androidArgs = AndroidArgs.load(yaml, cli)
+        assertThat(androidArgs.testRunnerClass).isEqualTo("com.foo.bar.TestRunner")
     }
 
     @Test

--- a/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/AndroidRunCommandTest.kt
+++ b/test_runner/src/test/kotlin/ftl/cli/firebase/test/android/AndroidRunCommandTest.kt
@@ -70,6 +70,7 @@ class AndroidRunCommandTest {
         assertThat(cmd.noUseOrchestrator).isNull()
         assertThat(cmd.performanceMetrics).isNull()
         assertThat(cmd.noPerformanceMetrics).isNull()
+        assertThat(cmd.testRunnerClass).isNull()
         assertThat(cmd.environmentVariables).isNull()
         assertThat(cmd.directoriesToPull).isNull()
         assertThat(cmd.device).isNull()
@@ -167,6 +168,14 @@ class AndroidRunCommandTest {
         CommandLine(cmd).parse("--no-performance-metrics")
 
         assertThat(cmd.noPerformanceMetrics).isTrue()
+    }
+
+    @Test
+    fun testRunnerClass_parse() {
+        val cmd = AndroidRunCommand()
+        CommandLine(cmd).parse("--test-runner-class=com.foo.bar.TestRunner")
+
+        assertThat(cmd.testRunnerClass).isEqualTo("com.foo.bar.TestRunner")
     }
 
     @Test

--- a/test_runner/src/test/kotlin/ftl/test/util/TestHelper.kt
+++ b/test_runner/src/test/kotlin/ftl/test/util/TestHelper.kt
@@ -6,7 +6,7 @@ import java.nio.file.Paths
 
 object TestHelper {
 
-    fun assert(actual: Any, expected: Any) =
+    fun assert(actual: Any?, expected: Any?) =
         Truth.assertThat(actual).isEqualTo(expected)
 
     fun getPath(path: String): Path =


### PR DESCRIPTION
Adds the `--test-runner-class` parameter (which is only applicable for the Android run command): https://cloud.google.com/sdk/gcloud/reference/firebase/test/android/run#--test-runner-class

Closes #459.