### PR TITLE
fix java.lang.NumberFormatException: empty String

### DIFF
--- a/test_runner/src/main/kotlin/ftl/reports/xml/model/JUnitTestSuite.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/xml/model/JUnitTestSuite.kt
@@ -2,6 +2,7 @@ package ftl.reports.xml.model
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty
+import java.util.Locale
 
 data class JUnitTestSuite(
     @JacksonXmlProperty(isAttribute = true)
@@ -78,7 +79,7 @@ data class JUnitTestSuite(
     }
 
     private fun mergeDouble(a: String?, b: String?): String {
-        return "%.3f".format((a.clean().toDouble() + b.clean().toDouble()))
+        return "%.3f".format(Locale.ROOT, (a.clean().toDouble() + b.clean().toDouble()))
     }
 
     fun merge(other: JUnitTestSuite): JUnitTestSuite {


### PR DESCRIPTION
On my default local `"%.3f".format()` return string like 1,23 instead of 1.23.
So, the `clean()` extention removes the comma and it causes the acc var to get "infinity", which becomes `""` after `clean()` and cause `NumberFormatException`

If I run the unit tests locally it fails: 
```ftl.reports.xml.JUnitXmlTest > merge android FAILED
expected: 6.148
but was : 6,148
    at ftl.reports.xml.JUnitXmlTest.merge android(JUnitXmlTest.kt:51)
```
https://stackoverflow.com/questions/43963633/java-double-to-string-format