### PR TITLE
FTL is now sometimes adding a `testLabExecutionId` on <testsuite

### DIFF
--- a/test_runner/src/main/kotlin/ftl/reports/xml/model/JUnitTestSuite.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/xml/model/JUnitTestSuite.kt
@@ -31,6 +31,10 @@ data class JUnitTestSuite(
     @JacksonXmlProperty(isAttribute = true)
     val hostname: String, // String.
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JacksonXmlProperty(isAttribute = true)
+    val testLabExecutionId: String?, // String.
+
     @JacksonXmlProperty(localName = "testcase")
     var testcases: MutableCollection<JUnitTestCase>?,
 

--- a/test_runner/src/test/kotlin/Tmp.kt
+++ b/test_runner/src/test/kotlin/Tmp.kt
@@ -138,6 +138,7 @@ object Tmp {
             time = overview.time(),
             timestamp = "",
             hostname = "localhost",
+            testLabExecutionId = "",
             testcases = testCases
         )
 

--- a/test_runner/src/test/kotlin/ftl/fixtures/ftl_junit_xml/android_pass.xml
+++ b/test_runner/src/test/kotlin/ftl/fixtures/ftl_junit_xml/android_pass.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8' ?>
-<testsuite name="" tests="1" failures="0" errors="0" skipped="0" time="2.278" timestamp="2018-09-14T20:45:55" hostname="localhost">
+<testsuite name="" tests="1" failures="0" errors="0" skipped="0" time="2.278" timestamp="2018-09-14T20:45:55" hostname="localhost" testLabExecutionId="matrix-1234_execution-asdf">
   <properties />
   <testcase name="testPasses" classname="com.example.app.ExampleUiTest" time="0.328" />
 </testsuite>

--- a/test_runner/src/test/kotlin/ftl/reports/utils/ReportManagerTest.kt
+++ b/test_runner/src/test/kotlin/ftl/reports/utils/ReportManagerTest.kt
@@ -62,7 +62,7 @@ class ReportManagerTest {
             JUnitTestCase("b", "b", "20.0"),
             JUnitTestCase("c", "c", "30.0")
         )
-        val oldRunSuite = JUnitTestSuite("", "-1", "-1", "-1", "-1", "-1", "-1", "-1", oldRunTestCases, null, null, null)
+        val oldRunSuite = JUnitTestSuite("", "-1", "-1", "-1", "-1", "-1", "-1", "-1", "-1", oldRunTestCases, null, null, null)
         val oldTestResult = JUnitTestResult(mutableListOf(oldRunSuite))
 
         val newRunTestCases = mutableListOf(
@@ -70,7 +70,7 @@ class ReportManagerTest {
             JUnitTestCase("b", "b", "21.0"),
             JUnitTestCase("c", "c", "30.0")
         )
-        val newRunSuite = JUnitTestSuite("", "-1", "-1", "-1", "-1", "-1", "-1", "-1", newRunTestCases, null, null, null)
+        val newRunSuite = JUnitTestSuite("", "-1", "-1", "-1", "-1", "-1", "-1", "-1", "-1", newRunTestCases, null, null, null)
         val newTestResult = JUnitTestResult(mutableListOf(newRunSuite))
 
         val mockArgs = mock(AndroidArgs::class.java)

--- a/test_runner/src/test/kotlin/ftl/reports/xml/JUnitXmlTest.kt
+++ b/test_runner/src/test/kotlin/ftl/reports/xml/JUnitXmlTest.kt
@@ -51,11 +51,12 @@ class JUnitXmlTest {
         assertThat(testSuite.time).isEqualTo((3.87 + 2.278).toString())
         assertThat(testSuite.timestamp).isEqualTo("2018-09-14T20:45:55")
         assertThat(testSuite.hostname).isEqualTo("localhost")
+        assertThat(testSuite.testLabExecutionId).isEqualTo("matrix-1234_execution-asdf")
 
         val expected = """
 <?xml version='1.0' encoding='UTF-8' ?>
 <testsuites>
-  <testsuite name="" tests="3" failures="1" errors="0" skipped="0" time="6.148" timestamp="2018-09-14T20:45:55" hostname="localhost">
+  <testsuite name="" tests="3" failures="1" errors="0" skipped="0" time="6.148" timestamp="2018-09-14T20:45:55" hostname="localhost" testLabExecutionId="matrix-1234_execution-asdf">
     <testcase name="testPasses" classname="com.example.app.ExampleUiTest" time="0.328"/>
     <testcase name="testFails" classname="com.example.app.ExampleUiTest" time="0.857">
       <failure>junit.framework.AssertionFailedError: expected:&lt;true> but was:&lt;false>
@@ -145,7 +146,7 @@ junit.framework.Assert.fail(Assert.java:50)</failure>
         val expected = """
 <?xml version='1.0' encoding='UTF-8' ?>
 <testsuites>
-  <testsuite name="" tests="1" failures="0" errors="0" skipped="0" time="2.278" timestamp="2018-09-14T20:45:55" hostname="localhost">
+  <testsuite name="" tests="1" failures="0" errors="0" skipped="0" time="2.278" timestamp="2018-09-14T20:45:55" hostname="localhost" testLabExecutionId="matrix-1234_execution-asdf">
     <testcase name="testPasses" classname="com.example.app.ExampleUiTest" time="0.328"/>
   </testsuite>
 </testsuites>

--- a/test_runner/src/test/kotlin/ftl/shard/ShardTest.kt
+++ b/test_runner/src/test/kotlin/ftl/shard/ShardTest.kt
@@ -7,14 +7,14 @@ import ftl.reports.xml.model.JUnitTestCase
 import ftl.reports.xml.model.JUnitTestResult
 import ftl.reports.xml.model.JUnitTestSuite
 import ftl.test.util.FlankTestRunner
-import java.util.concurrent.TimeUnit
-import kotlin.system.measureNanoTime
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.ExpectedException
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
+import java.util.concurrent.TimeUnit
+import kotlin.system.measureNanoTime
 
 @RunWith(FlankTestRunner::class)
 class ShardTest {
@@ -34,8 +34,9 @@ class ShardTest {
             JUnitTestCase("g", "g", "1.0")
         )
 
-        val suite1 = JUnitTestSuite("", "-1", "-1", "-1", "-1", "-1", "-1", "-1", testCases, null, null, null)
-        val suite2 = JUnitTestSuite("", "-1", "-1", "-1", "-1", "-1", "-1", "-1", mutableListOf(), null, null, null)
+        val suite1 = JUnitTestSuite("", "-1", "-1", "-1", "-1", "-1", "-1", "-1", "-1", testCases, null, null, null)
+        val suite2 =
+            JUnitTestSuite("", "-1", "-1", "-1", "-1", "-1", "-1", "-1", "-1", mutableListOf(), null, null, null)
 
         return JUnitTestResult(mutableListOf(suite1, suite2))
     }
@@ -171,6 +172,7 @@ class ShardTest {
                         "12.032",
                         "2019-07-27T08:15:04",
                         "localhost",
+                        "matrix-1234_execution-asdf",
                         testCases,
                         null,
                         null,


### PR DESCRIPTION
We started getting some failures because some of the junit xml's coming back from FTL had an `testLabExecutionId` attribute on `<testsuite`.

This adds the property to the model class so it can deserialize correctly. 