### PR TITLE
Disable FAIL_ON_UNKNOWN_PROPERTIES for forward compatibility

### DIFF
--- a/test_runner/src/main/kotlin/ftl/reports/xml/JUnitXml.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/xml/JUnitXml.kt
@@ -3,6 +3,7 @@ package ftl.reports.xml
 import com.fasterxml.jackson.dataformat.xml.JacksonXmlModule
 import com.fasterxml.jackson.dataformat.xml.XmlMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
 import ftl.reports.xml.model.JUnitTestResult
 import ftl.reports.xml.model.JUnitTestSuite
 import java.io.File
@@ -12,6 +13,8 @@ import java.nio.file.Path
 private val xmlModule = JacksonXmlModule().apply { setDefaultUseWrapper(false) }
 private val xmlMapper = XmlMapper(xmlModule)
     .registerModules(KotlinModule())
+    .configure(FAIL_ON_UNKNOWN_PROPERTIES, true)
+
 private val xmlPrettyWriter = xmlMapper.writerWithDefaultPrettyPrinter()
 
 private fun xmlBytes(path: Path): ByteArray {

--- a/test_runner/src/main/kotlin/ftl/reports/xml/JUnitXml.kt
+++ b/test_runner/src/main/kotlin/ftl/reports/xml/JUnitXml.kt
@@ -13,7 +13,7 @@ import java.nio.file.Path
 private val xmlModule = JacksonXmlModule().apply { setDefaultUseWrapper(false) }
 private val xmlMapper = XmlMapper(xmlModule)
     .registerModules(KotlinModule())
-    .configure(FAIL_ON_UNKNOWN_PROPERTIES, true)
+    .configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
 
 private val xmlPrettyWriter = xmlMapper.writerWithDefaultPrettyPrinter()
 

--- a/test_runner/src/test/kotlin/ftl/reports/xml/JUnitXmlTest.kt
+++ b/test_runner/src/test/kotlin/ftl/reports/xml/JUnitXmlTest.kt
@@ -141,6 +141,32 @@ junit.framework.Assert.fail(Assert.java:50)</failure>
     }
 
     @Test
+    fun `unknown xml property`() {
+        val unknownXml= """
+<?xml version='1.0' encoding='UTF-8' ?>
+<testsuites>
+  <testsuite random="prop" name="EarlGreyExampleSwiftTests" tests="4" failures="1" errors="0" skipped="0" time="51.773" hostname="localhost">
+    <testcase name="a()" classname="a" time="1.0" random="prop"/>
+  </testsuite>
+</testsuites>
+        """.trimIndent()
+
+        val expected = """
+<?xml version='1.0' encoding='UTF-8' ?>
+<testsuites>
+  <testsuite name="EarlGreyExampleSwiftTests" tests="4" failures="1" errors="0" skipped="0" time="51.773" hostname="localhost">
+    <testcase name="a()" classname="a" time="1.0"/>
+  </testsuite>
+</testsuites>
+
+        """.trimIndent()
+
+        val parsed = parseAllSuitesXml(unknownXml).xmlToString()
+
+        assertThat(parsed).isEqualTo(expected)
+    }
+
+    @Test
     fun `junitXmlToString androidPassXml`() {
         val parsed = parseOneSuiteXml(androidPassXml).xmlToString()
         val expected = """

--- a/test_runner/src/test/kotlin/ftl/reports/xml/JUnitXmlTest.kt
+++ b/test_runner/src/test/kotlin/ftl/reports/xml/JUnitXmlTest.kt
@@ -142,7 +142,7 @@ junit.framework.Assert.fail(Assert.java:50)</failure>
 
     @Test
     fun `unknown xml property`() {
-        val unknownXml= """
+        val unknownXml = """
 <?xml version='1.0' encoding='UTF-8' ?>
 <testsuites>
   <testsuite random="prop" name="EarlGreyExampleSwiftTests" tests="4" failures="1" errors="0" skipped="0" time="51.773" hostname="localhost">


### PR DESCRIPTION
This makes sure that any future additions to the XML by FTL does not break existing builds of flank and is more permissive in structure about deserialization of unknown properties.